### PR TITLE
NPE fixes if handler method is not present

### DIFF
--- a/restdocs-jackson/src/main/java/capital/scalable/restdocs/jackson/misc/DescriptionSnippet.java
+++ b/restdocs-jackson/src/main/java/capital/scalable/restdocs/jackson/misc/DescriptionSnippet.java
@@ -20,9 +20,14 @@ public class DescriptionSnippet extends TemplatedSnippet {
     protected Map<String, Object> createModel(Operation operation) {
         HandlerMethod handlerMethod = getHandlerMethod(operation);
 
-        String methodComment = getJavadocReader(operation)
-                .resolveMethodComment(handlerMethod.getBeanType(),
-                        handlerMethod.getMethod().getName());
+        final String methodComment;
+        if (handlerMethod != null) {
+            methodComment = getJavadocReader(operation)
+                    .resolveMethodComment(handlerMethod.getBeanType(),
+                            handlerMethod.getMethod().getName());
+        } else {
+            methodComment = "";
+        }
 
         Map<String, Object> model = new HashMap<>();
         model.put("description", methodComment);

--- a/restdocs-jackson/src/main/java/capital/scalable/restdocs/jackson/misc/MethodAndPathSnippet.java
+++ b/restdocs-jackson/src/main/java/capital/scalable/restdocs/jackson/misc/MethodAndPathSnippet.java
@@ -19,7 +19,15 @@ public class MethodAndPathSnippet extends TemplatedSnippet {
     protected Map<String, Object> createModel(Operation operation) {
         Map<String, Object> model = new HashMap<>();
         model.put("method", getRequestMethod(operation));
-        model.put("path", getRequestPattern(operation));
+        model.put("path", nullToEmpty(getRequestPattern(operation)));
         return model;
+    }
+
+    private String nullToEmpty(String s) {
+        if (s == null) {
+            return "";
+        } else {
+            return s;
+        }
     }
 }

--- a/restdocs-jackson/src/main/java/capital/scalable/restdocs/jackson/misc/SectionSnippet.java
+++ b/restdocs-jackson/src/main/java/capital/scalable/restdocs/jackson/misc/SectionSnippet.java
@@ -30,8 +30,13 @@ public class SectionSnippet extends TemplatedSnippet {
     @Override
     protected Map<String, Object> createModel(Operation operation) {
         HandlerMethod handlerMethod = getHandlerMethod(operation);
-        String title = join(splitByCharacterTypeCamelCase(
-                capitalize(handlerMethod.getMethod().getName())), ' ');
+        final String title;
+        if (handlerMethod != null) {
+            title = join(splitByCharacterTypeCamelCase(
+                    capitalize(handlerMethod.getMethod().getName())), ' ');
+        } else {
+            title = "";
+        }
 
         // resolve path
         String path = propertyPlaceholderHelper.replacePlaceholders(operation.getName(),


### PR DESCRIPTION
Ran into this while executing `UserApiDocumentation.login`. It tests `/api/oauth2/token`.

Still need to add tests.
