### PR TITLE
better support for recursive structures

### DIFF
--- a/restdocs-jackson-example/pom.xml
+++ b/restdocs-jackson-example/pom.xml
@@ -65,8 +65,7 @@
         <dependency>
             <groupId>capital.scalable</groupId>
             <artifactId>restdocs-jackson</artifactId>
-            <version>1.0.2-SNAPSHOT</version>
-            <scope>test</scope>
+            <version>1.0.3-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.javamoney</groupId>

--- a/restdocs-jackson-example/src/main/java/capital/scalable/example/items/ItemResponse.java
+++ b/restdocs-jackson-example/src/main/java/capital/scalable/example/items/ItemResponse.java
@@ -26,6 +26,7 @@ import javax.validation.constraints.Size;
 import java.math.BigDecimal;
 import java.util.List;
 
+import capital.scalable.restdocs.jackson.jackson.RestdocsNotExpanded;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import lombok.AllArgsConstructor;
@@ -60,10 +61,11 @@ class ItemResponse {
     private Attributes attributes;
 
     /**
-     * Child items.
+     * Child items (recursive). Same structure as this response.
      */
     @Valid
     @NotEmpty
+    @RestdocsNotExpanded
     private List<ItemResponse> children;
 
     /**

--- a/restdocs-jackson/src/main/java/capital/scalable/restdocs/jackson/jackson/FieldDocumentationObjectVisitor.java
+++ b/restdocs-jackson/src/main/java/capital/scalable/restdocs/jackson/jackson/FieldDocumentationObjectVisitor.java
@@ -61,9 +61,11 @@ public class FieldDocumentationObjectVisitor extends JsonObjectFormatVisitor.Bas
         String fieldPath = path + (path.isEmpty() ? "" : ".") + jsonName;
         Class<?> javaBaseClass = prop.getMember().getDeclaringClass();
         List<Annotation> annotations = getAnnotations(prop);
+        boolean shouldExpand = shouldExpand(prop);
 
         InternalFieldInfo fieldInfo =
-                new InternalFieldInfo(javaBaseClass, fieldName, fieldPath, annotations);
+                new InternalFieldInfo(javaBaseClass, fieldName, fieldPath, annotations,
+                        shouldExpand);
 
         JsonFormatVisitorWrapper visitor =
                 new FieldDocumentationVisitorWrapper(getProvider(), context, fieldPath, fieldInfo);
@@ -84,5 +86,9 @@ public class FieldDocumentationObjectVisitor extends JsonObjectFormatVisitor.Bas
             ser = getProvider().findValueSerializer(prop.getType(), prop);
         }
         return ser;
+    }
+
+    private boolean shouldExpand(BeanProperty prop) {
+        return prop.getMember().getAnnotation(RestdocsNotExpanded.class) == null;
     }
 }

--- a/restdocs-jackson/src/main/java/capital/scalable/restdocs/jackson/jackson/FieldDocumentationVisitorContext.java
+++ b/restdocs-jackson/src/main/java/capital/scalable/restdocs/jackson/jackson/FieldDocumentationVisitorContext.java
@@ -24,9 +24,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import capital.scalable.restdocs.jackson.constraints.ConstraintReader;
 import capital.scalable.restdocs.jackson.javadoc.JavadocReader;
@@ -34,7 +32,6 @@ import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.snippet.Attributes.Attribute;
 
 public class FieldDocumentationVisitorContext {
-    private final Set<Class<?>> analyzedClasses = new HashSet<>();
     private final List<FieldDescriptor> fields = new ArrayList<>();
     private JavadocReader javadocReader;
     private ConstraintReader constraintReader;
@@ -119,13 +116,5 @@ public class FieldDocumentationVisitorContext {
         }
 
         return descriptions;
-    }
-
-    public void addAnalyzedClass(Class<?> clazz) {
-        analyzedClasses.add(clazz);
-    }
-
-    public boolean wasAnalyzed(Class<?> clazz) {
-        return analyzedClasses.contains(clazz);
     }
 }

--- a/restdocs-jackson/src/main/java/capital/scalable/restdocs/jackson/jackson/FieldDocumentationVisitorWrapper.java
+++ b/restdocs-jackson/src/main/java/capital/scalable/restdocs/jackson/jackson/FieldDocumentationVisitorWrapper.java
@@ -70,18 +70,21 @@ public class FieldDocumentationVisitorWrapper implements JsonFormatVisitorWrappe
     @Override
     public JsonObjectFormatVisitor expectObjectFormat(JavaType type) throws JsonMappingException {
         addFieldIfPresent("Object");
-        if (context.wasAnalyzed(type.getRawClass())) {
-            return null;
-        } else {
-            context.addAnalyzedClass(type.getRawClass());
+        if (shouldExpand()) {
             return new FieldDocumentationObjectVisitor(provider, context, path);
+        } else {
+            return new JsonObjectFormatVisitor.Base();
         }
     }
 
     @Override
     public JsonArrayFormatVisitor expectArrayFormat(JavaType type) throws JsonMappingException {
         addFieldIfPresent("Array");
-        return new FieldDocumentationArrayVisitor(provider, context, path);
+        if (shouldExpand()) {
+            return new FieldDocumentationArrayVisitor(provider, context, path);
+        } else {
+            return new JsonArrayFormatVisitor.Base();
+        }
     }
 
     @Override
@@ -134,5 +137,9 @@ public class FieldDocumentationVisitorWrapper implements JsonFormatVisitorWrappe
         if (fieldInfo != null) {
             context.addField(fieldInfo, fieldType);
         }
+    }
+
+    private boolean shouldExpand() {
+        return fieldInfo == null || fieldInfo.shouldExpand();
     }
 }

--- a/restdocs-jackson/src/main/java/capital/scalable/restdocs/jackson/jackson/InternalFieldInfo.java
+++ b/restdocs-jackson/src/main/java/capital/scalable/restdocs/jackson/jackson/InternalFieldInfo.java
@@ -24,13 +24,15 @@ class InternalFieldInfo {
     private final String javaFieldName;
     private final String jsonFieldPath;
     private List<Annotation> annotations;
+    private final boolean shouldExpand;
 
     public InternalFieldInfo(Class<?> javaBaseClass, String javaFieldName,
-            String jsonFieldPath, List<Annotation> annotations) {
+            String jsonFieldPath, List<Annotation> annotations, boolean shouldExpand) {
         this.javaBaseClass = javaBaseClass;
         this.javaFieldName = javaFieldName;
         this.jsonFieldPath = jsonFieldPath;
         this.annotations = annotations;
+        this.shouldExpand = shouldExpand;
     }
 
     public Class<?> getJavaBaseClass() {
@@ -47,5 +49,9 @@ class InternalFieldInfo {
 
     public List<Annotation> getAnnotations() {
         return annotations;
+    }
+
+    public boolean shouldExpand() {
+        return shouldExpand;
     }
 }

--- a/restdocs-jackson/src/main/java/capital/scalable/restdocs/jackson/jackson/RestdocsNotExpanded.java
+++ b/restdocs-jackson/src/main/java/capital/scalable/restdocs/jackson/jackson/RestdocsNotExpanded.java
@@ -1,0 +1,26 @@
+package capital.scalable.restdocs.jackson.jackson;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import javax.validation.Payload;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Does not expand this field (e.g. because it's already defined in custom section or to prevent
+ * infinite recursion in certain structures).
+ */
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER})
+@Retention(RUNTIME)
+public @interface RestdocsNotExpanded {
+    String message() default "";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}


### PR DESCRIPTION
remembering types which were already serialized and suppress them is not a good solution to fix recursive problem, especially if they are simple and they just want to be expanded within single response.
I added @RestdocsNotExpanded annotation which prevents expanding any custom type, and is useful to prevent infinite recursion.
Also one test `testGenerateDocumentationForComposedTypes` was wrong because of previous handling
