### PR TITLE
Updated test in example to Spring Boot 1.4 changes

### DIFF
--- a/restdocs-jackson-example/src/test/java/capital/scalable/example/testsupport/MockMvcBase.java
+++ b/restdocs-jackson-example/src/test/java/capital/scalable/example/testsupport/MockMvcBase.java
@@ -47,19 +47,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import javax.servlet.Filter;
 
-import capital.scalable.example.Application;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.restdocs.JUnitRestDocumentation;
 import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -69,9 +67,8 @@ import org.springframework.web.context.WebApplicationContext;
 /**
  * Required set up code for MockMvc tests.
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = {Application.class})
-@WebAppConfiguration
+@RunWith(SpringRunner.class)
+@SpringBootTest
 public abstract class MockMvcBase {
 
     private static final String DEFAULT_AUTHORIZATION = "Resource is public.";


### PR DESCRIPTION
Spring Boot 1.4 simplified the config and `@SpringApplicationConfiguration` is marked as deprecated now.
