### PR TITLE
Document usage with Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ to the code increases the maintainability of the documentation.
 
 In Spring REST Docs you have to add the documentation for your JSON with
 a DSL in your test. We moved this documentation to the POJO that represents
-your JSON object. You just add JavaDoc to the fields and it will end
+your JSON object. You just add Javadoc to the fields and it will end
 up in the documentation.
 
 ## Features:
 
-* Jackson visitor that gathers the whole JSON structure and includes JavaDoc
+* Jackson visitor that gathers the whole JSON structure and includes Javadoc
 and constraint annotations on the fields. It works for both request and
 response bodies. In addition to the constraint documentation support that
 is already Spring REST Docs, we automatically include the constraint message

--- a/docs/index.html
+++ b/docs/index.html
@@ -428,34 +428,34 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
 <ul class="sectlevel1">
-    <li><a href="#faq">FAQ</a></li>
-    <li><a href="#gettingstarted">Getting started</a>
+<li><a href="#faq">FAQ</a></li>
+<li><a href="#gettingstarted">Getting started</a>
 <ul class="sectlevel2">
-    <li><a href="#gettingstarted-requirements">Requirements</a></li>
-    <li><a href="#gettingstarted-usage">Usage</a></li>
-    <li><a href="#gettingstarted-sample">Sample application</a></li>
+<li><a href="#gettingstarted-requirements">Requirements</a></li>
+<li><a href="#gettingstarted-usage">Usage</a></li>
+<li><a href="#gettingstarted-sample">Sample application</a></li>
 </ul>
 </li>
-    <li><a href="#snippets">Snippets</a>
+<li><a href="#snippets">Snippets</a>
 <ul class="sectlevel2">
-    <li><a href="#snippets-authorization">Authorization snippet</a></li>
-    <li><a href="#snippets-path-parameters">Path parameter snippet</a></li>
-    <li><a href="#snippets-request-parameters">Request parameter snippet</a></li>
-    <li><a href="#snippets-section">Section snippet</a></li>
+<li><a href="#snippets-authorization">Authorization snippet</a></li>
+<li><a href="#snippets-path-parameters">Path parameter snippet</a></li>
+<li><a href="#snippets-request-parameters">Request parameter snippet</a></li>
+<li><a href="#snippets-section">Section snippet</a></li>
 </ul>
 </li>
-    <li><a href="#constraints">Documenting constraints</a>
+<li><a href="#constraints">Documenting constraints</a>
 <ul class="sectlevel2">
-    <li><a href="#constraints-optionality">Constraint that determine optionality</a></li>
-    <li><a href="#constraints-custom">Custom constraints</a></li>
-    <li><a href="#constraints-enums">Enums</a></li>
-    <li><a href="#constraints-readable-values">Readable constraint values</a></li>
-    <li><a href="#constraints-groups">Constraint groups</a></li>
+<li><a href="#constraints-optionality">Constraint that determine optionality</a></li>
+<li><a href="#constraints-custom">Custom constraints</a></li>
+<li><a href="#constraints-enums">Enums</a></li>
+<li><a href="#constraints-readable-values">Readable constraint values</a></li>
+<li><a href="#constraints-groups">Constraint groups</a></li>
 </ul>
 </li>
-    <li><a href="#contributing">Contributing</a>
+<li><a href="#contributing">Contributing</a>
 <ul class="sectlevel2">
-    <li><a href="#contributing-building">Building from source</a></li>
+<li><a href="#contributing-building">Building from source</a></li>
 </ul>
 </li>
 </ul>
@@ -474,7 +474,7 @@ to the code increases the maintainability of the documentation.</p>
 <div class="paragraph">
 <p>In Spring REST Docs you have to add the documentation for your JSON with
 a DSL in your test. We moved this documentation to the POJO that represents
-your JSON object. You just add JavaDoc to the fields and it will end
+your JSON object. You just add Javadoc to the fields and it will end
 up in the documentation.</p>
 </div>
 <div class="paragraph">
@@ -483,7 +483,7 @@ up in the documentation.</p>
 <div class="ulist">
 <ul>
 <li>
-<p>Jackson visitor that gathers the whole JSON structure and includes JavaDoc
+<p>Jackson visitor that gathers the whole JSON structure and includes Javadoc
 and constraint annotations on the fields. It works for both request and
 response bodies. In addition to the constraint documentation support that
 is already Spring REST Docs, we automatically include the constraint message
@@ -504,7 +504,7 @@ you write even less.</p>
 </div>
 </div>
 <div class="sect1">
-    <h2 id="faq"><a class="link" href="#faq">FAQ</a></h2>
+<h2 id="faq"><a class="link" href="#faq">FAQ</a></h2>
 <div class="sectionbody">
 <div class="qlist qanda">
 <ol>
@@ -525,10 +525,10 @@ you write even less.</p>
 </div>
 </div>
 <div class="sect1">
-    <h2 id="gettingstarted"><a class="link" href="#gettingstarted">Getting started</a></h2>
+<h2 id="gettingstarted"><a class="link" href="#gettingstarted">Getting started</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-    <h3 id="gettingstarted-requirements"><a class="link" href="#gettingstarted-requirements">Requirements</a></h3>
+<h3 id="gettingstarted-requirements"><a class="link" href="#gettingstarted-requirements">Requirements</a></h3>
 <div class="paragraph">
 <p>Spring Auto REST Docs has the following minimum requirements:</p>
 </div>
@@ -547,32 +547,42 @@ you write even less.</p>
 </div>
 </div>
 <div class="sect2">
-    <h3 id="gettingstarted-usage"><a class="link" href="#gettingstarted-usage">Usage</a></h3>
+<h3 id="gettingstarted-usage"><a class="link" href="#gettingstarted-usage">Usage</a></h3>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
 <p>Setup project for <a href="http://docs.spring.io/spring-restdocs/docs/1.1.2.RELEASE/reference/html5/#getting-started">Spring REST Docs</a></p>
 </li>
 <li>
-<p>Configure maven dependency:</p>
-<div class="listingblock secondary">
+<p>Additional configuration for this extension:</p>
+<div class="listingblock primary">
+<div class="title">Maven</div>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-xml" data-lang="xml">&lt;dependency&gt;
     &lt;groupId&gt;capital.scalable&lt;/groupId&gt;
     &lt;artifactId&gt;spring-auto-restdocs-core&lt;/artifactId&gt;
     &lt;version&gt;1.0.5&lt;/version&gt;
-    &lt;scope&gt;test&lt;/scope&gt;
-&lt;/dependency&gt;</code></pre>
-</div>
-</div>
-</li>
-<li>
-<p>Configure Maven JavaDoc plugin:</p>
-<div class="listingblock secondary">
-<div class="content">
-<pre class="highlightjs highlight"><code class="language-xml" data-lang="xml">&lt;build&gt;
+    &lt;scope&gt;test&lt;/scope&gt; <i class="conum" data-value="1"></i><b>(1)</b>
+&lt;/dependency&gt;
+
+&lt;build&gt;
     &lt;plugins&gt;
-        ...
+        &lt;plugin&gt;
+            &lt;artifactId&gt;maven-surefire-plugin&lt;/artifactId&gt;
+             &lt;configuration&gt;
+                &lt;includes&gt;
+                    &lt;include&gt;**/*Test.java&lt;/include&gt;
+                &lt;/includes&gt;
+                &lt;systemPropertyVariables&gt;
+                    &lt;org.springframework.restdocs.outputDir&gt;
+                        ${snippetsDirectory}
+                    &lt;/org.springframework.restdocs.outputDir&gt;
+                    &lt;org.springframework.restdocs.javadocJsonDir&gt;
+                        ${project.build.directory}/generated-javadoc-json
+                    &lt;/org.springframework.restdocs.javadocJsonDir&gt;
+                &lt;/systemPropertyVariables&gt;
+             &lt;/configuration&gt;
+        &lt;/plugin&gt;
         &lt;plugin&gt;
             &lt;artifactId&gt;maven-javadoc-plugin&lt;/artifactId&gt;
             &lt;extensions&gt;true&lt;/extensions&gt;
@@ -601,6 +611,59 @@ you write even less.</p>
     &lt;/plugins&gt;
 &lt;/build&gt;</code></pre>
 </div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>Has to be removed if <code>@RestdocsNotExpanded</code> is used.</td>
+</tr>
+</table>
+</div>
+<div class="listingblock secondary">
+<div class="title">Gradle</div>
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-groovy" data-lang="groovy">configurations {
+    jsondoclet
+}
+
+ext {
+    javadocJsonDir = file("$buildDir/generated-javadoc-json")
+}
+
+dependencies {
+    testCompile group: 'capital.scalable', name: 'spring-auto-restdocs-core', version: '1.0.5' <i class="conum" data-value="1"></i><b>(1)</b>
+    jsondoclet group: 'capital.scalable', name: 'spring-auto-restdocs-json-doclet', version: '1.0.5'
+}
+
+task jsonDoclet(type: Javadoc, dependsOn: compileJava) {
+    source = sourceSets.main.allJava
+    classpath = sourceSets.main.compileClasspath
+    destinationDir = javadocJsonDir
+    options.docletpath = configurations.jsondoclet.files.asType(List)
+    options.doclet = 'capital.scalable.restdocs.jsondoclet.ExtractDocumentationAsJsonDoclet'
+    options.memberLevel = JavadocMemberLevel.PACKAGE
+}
+
+test {
+    systemProperty 'org.springframework.restdocs.outputDir', snippetsDir
+    systemProperty 'org.springframework.restdocs.javadocJsonDir', javadocJsonDir
+
+    dependsOn jsonDoclet
+}
+
+jar {
+    dependsOn asciidoctor
+}</code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>Has to be <code>compile</code> instead of <code>testCompile</code> if <code>@RestdocsNotExpanded</code> is used.</td>
+</tr>
+</table>
 </div>
 </li>
 <li>
@@ -656,7 +719,7 @@ public void setUp() throws Exception {
 </div>
 </div>
 <div class="sect2">
-    <h3 id="gettingstarted-sample"><a class="link" href="#gettingstarted-sample">Sample application</a></h3>
+<h3 id="gettingstarted-sample"><a class="link" href="#gettingstarted-sample">Sample application</a></h3>
 <div class="paragraph">
 <p><a href="https://github.com/ScaCap/spring-auto-restdocs/tree/master/spring-auto-restdocs-example">This project</a> includes a sample application that demonstrates most features:</p>
 </div>
@@ -667,10 +730,10 @@ public void setUp() throws Exception {
 </div>
 </div>
 <div class="sect1">
-    <h2 id="snippets"><a class="link" href="#snippets">Snippets</a></h2>
+<h2 id="snippets"><a class="link" href="#snippets">Snippets</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-    <h3 id="snippets-authorization"><a class="link" href="#snippets-authorization">Authorization snippet</a></h3>
+<h3 id="snippets-authorization"><a class="link" href="#snippets-authorization">Authorization snippet</a></h3>
 <div class="paragraph">
 <p>The authorization snippet does not help in adding authorization to your tests, but it makes it easy to document your authorization information.
 Usually, a custom <code>RequestPostProcessor</code> is used to add authorization and this is also the place where you add the documentation.</p>
@@ -692,9 +755,9 @@ Usually, a custom <code>RequestPostProcessor</code> is used to add authorization
 </div>
 </div>
 <div class="sect2">
-    <h3 id="snippets-path-parameters"><a class="link" href="#snippets-path-parameters">Path parameter snippet</a></h3>
+<h3 id="snippets-path-parameters"><a class="link" href="#snippets-path-parameters">Path parameter snippet</a></h3>
 <div class="paragraph">
-<p>The path parameter snippet automatically lists parameters in the path including their type, whether they are optional, and their JavaDoc.</p>
+<p>The path parameter snippet automatically lists parameters in the path including their type, whether they are optional, and their Javadoc.</p>
 </div>
 <div class="listingblock secondary">
 <div class="title">Code</div>
@@ -739,9 +802,9 @@ public ItemResponse getItem(@PathVariable("id") String id) {</code></pre>
 </table>
 </div>
 <div class="sect2">
-    <h3 id="snippets-request-parameters"><a class="link" href="#snippets-request-parameters">Request parameter snippet</a></h3>
+<h3 id="snippets-request-parameters"><a class="link" href="#snippets-request-parameters">Request parameter snippet</a></h3>
 <div class="paragraph">
-<p>The request parameter snippet automatically lists query parameters including their type, whether they are optional, and their JavaDoc.</p>
+<p>The request parameter snippet automatically lists query parameters including their type, whether they are optional, and their Javadoc.</p>
 </div>
 <div class="listingblock secondary">
 <div class="title">Code</div>
@@ -780,11 +843,11 @@ public Page&lt;ItemResponse&gt; searchItem(@RequestParam("desc") String descMatc
 </table>
 </div>
 <div class="sect2">
-    <h3 id="snippets-section"><a class="link" href="#snippets-section">Section snippet</a></h3>
+<h3 id="snippets-section"><a class="link" href="#snippets-section">Section snippet</a></h3>
 <div class="paragraph">
 <p>The section snippet combines all snippets in this REST Docs extensions and also includes unmodified snippets from Spring REST Docs.
 It helps you being even more lazy, because a single line of AsciiDoc is sufficient to document one endpoint.
-Assuming of course that you already documented your code with JavaDoc.</p>
+Assuming of course that you already documented your code with Javadoc.</p>
 </div>
 <div class="listingblock secondary">
 <div class="title">Asciidoc</div>
@@ -861,7 +924,7 @@ include::{snippets}/{{path}}/http-response.adoc[]</code></pre>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">description.adoc</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Get an item by its ID.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>DescriptionSnippet</code> reads the JavaDoc on the method.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>DescriptionSnippet</code> reads the Javadoc on the method.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">authorization.adoc</p></td>
@@ -871,22 +934,22 @@ include::{snippets}/{{path}}/http-response.adoc[]</code></pre>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">path-parameters.adoc</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>PathParametersSnippet</code> automatically lists parameters in the path including their type, whether they are optional, and their JavaDoc.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>PathParametersSnippet</code> automatically lists parameters in the path including their type, whether they are optional, and their Javadoc.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">request-parameters.adoc</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>RequestParametersSnippet</code> automatically lists query parameters including their type, whether they are optional, and their JavaDoc.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>RequestParametersSnippet</code> automatically lists query parameters including their type, whether they are optional, and their Javadoc.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">request-fields.adoc</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>JacksonRequestFieldSnippet</code> automatically lists all fields of the request body including their type, whether they are optional, and their JavaDoc.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>JacksonRequestFieldSnippet</code> automatically lists all fields of the request body including their type, whether they are optional, and their Javadoc.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">response-fields.adoc</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>JacksonResponseFieldSnippet</code> automatically lists all fields of the response body including their type, whether they are optional, and their JavaDoc.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>JacksonResponseFieldSnippet</code> automatically lists all fields of the response body including their type, whether they are optional, and their Javadoc.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">curl-request.adoc</p></td>
@@ -904,7 +967,7 @@ include::{snippets}/{{path}}/http-response.adoc[]</code></pre>
 </div>
 </div>
 <div class="sect1">
-    <h2 id="constraints"><a class="link" href="#constraints">Documenting constraints</a></h2>
+<h2 id="constraints"><a class="link" href="#constraints">Documenting constraints</a></h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p>Spring REST Docs has support for documenting constraints,
@@ -914,7 +977,7 @@ and the constraint groups to derive whether a field is optional
 and to add the constraint descriptions to the field descriptions.</p>
 </div>
 <div class="sect2">
-    <h3 id="constraints-optionality"><a class="link" href="#constraints-optionality">Constraint that determine optionality</a></h3>
+<h3 id="constraints-optionality"><a class="link" href="#constraints-optionality">Constraint that determine optionality</a></h3>
 <div class="paragraph">
 <p>The following three constraints are used to determine whether a field is optional.
 Their descriptions are not included in the field descriptions.</p>
@@ -934,14 +997,14 @@ Their descriptions are not included in the field descriptions.</p>
 </div>
 </div>
 <div class="sect2">
-    <h3 id="constraints-custom"><a class="link" href="#constraints-custom">Custom constraints</a></h3>
+<h3 id="constraints-custom"><a class="link" href="#constraints-custom">Custom constraints</a></h3>
 <div class="paragraph">
 <p>Descriptions for custom constraints can be provided in <code>org.springframework.restdocs.constraints.ConstraintDescriptions.properties</code>.
 If this file can be loaded as a resource, descriptions are extracted.
 Each description is a property where the key is the full class name of the annotation suffixed with <code>.description</code>.
 The value is the description and can contain placeholders for annotation methods,
-    e.g. <code>${value}</code> to get the content of <code>value()</code>.
-    For more details, see original documentation of <a href="http://docs.spring.io/spring-restdocs/docs/1.1.2.RELEASE/reference/html5/#documenting-your-api-constraints-describing">here</a>.</p>
+e.g. <code>${value}</code> to get the content of <code>value()</code>.
+For more details, see original documentation of <a href="http://docs.spring.io/spring-restdocs/docs/1.1.2.RELEASE/reference/html5/#documenting-your-api-constraints-describing">here</a>.</p>
 </div>
 <div class="paragraph">
 <p>Example for the constraint annotation <code>myproject.constraints.OneOf</code>:</p>
@@ -954,15 +1017,15 @@ The value is the description and can contain placeholders for annotation methods
 </div>
 </div>
 <div class="sect2">
-    <h3 id="constraints-enums"><a class="link" href="#constraints-enums">Enums</a></h3>
-    <div class="paragraph">
-        <p>Constraint message for enum is appended to description field as list of allowed values, e.g. <code>Must be one of [A, B]</code>.
-            If you want to customize this message, use <a href="#constraints-custom">above mentioned</a> <code>ConstraintDescriptions.properties</code> approach.
-            The list of values is represented by the <code>${value}</code> placeholder.</p>
+<h3 id="constraints-enums"><a class="link" href="#constraints-enums">Enums</a></h3>
+<div class="paragraph">
+<p>Constraint message for enum is appended to description field as list of allowed values, e.g. <code>Must be one of [A, B]</code>.
+If you want to customize this message, use <a href="#constraints-custom">above mentioned</a> <code>ConstraintDescriptions.properties</code> approach.
+The list of values is represented by the <code>${value}</code> placeholder.</p>
 </div>
 </div>
-    <div class="sect2">
-        <h3 id="constraints-readable-values"><a class="link" href="#constraints-readable-values">Readable constraint values</a></h3>
+<div class="sect2">
+<h3 id="constraints-readable-values"><a class="link" href="#constraints-readable-values">Readable constraint values</a></h3>
 <div class="paragraph">
 <p>Spring REST Docs just calls <code>toString()</code> objects extracted from
 the constraint for documentation.
@@ -983,16 +1046,16 @@ and <code>toString()</code> is called on the instance.</p>
 </div>
 </div>
 <div class="sect2">
-    <h3 id="constraints-groups"><a class="link" href="#constraints-groups">Constraint groups</a></h3>
+<h3 id="constraints-groups"><a class="link" href="#constraints-groups">Constraint groups</a></h3>
 <div class="paragraph">
 <p>Constraint groups are also included in the documentation if
 a description is provided for them.
 The descriptions are provided in the same way as for custom constraints.</p>
 </div>
 <div class="sect3">
-    <h4 id="constraints-examples"><a class="link" href="#constraints-examples">Examples</a></h4>
+<h4 id="constraints-examples"><a class="link" href="#constraints-examples">Examples</a></h4>
 <div class="sect4">
-    <h5 id="constraints-examples-descriptions"><a class="link" href="#constraints-examples-descriptions">Descriptions for the examples</a></h5>
+<h5 id="constraints-examples-descriptions"><a class="link" href="#constraints-examples-descriptions">Descriptions for the examples</a></h5>
 <div class="listingblock secondary">
 <div class="title">ConstraintDescriptions.properties</div>
 <div class="content">
@@ -1003,7 +1066,7 @@ myproject.constraints.OneOf.description=Must be one of ${value}</code></pre>
 </div>
 </div>
 <div class="sect4">
-    <h5 id="constraints-examples-optionality"><a class="link" href="#constraints-examples-optionality">Optionality description</a></h5>
+<h5 id="constraints-examples-optionality"><a class="link" href="#constraints-examples-optionality">Optionality description</a></h5>
 <div class="listingblock secondary">
 <div class="title">Code</div>
 <div class="content">
@@ -1031,15 +1094,15 @@ private String field;</code></pre>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">field</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-    <td class="tableblock halign-left valign-top"><p class="tableblock">true<br>
-        EN: false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true<br>
+EN: false</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
-    <h5 id="constraints-examples-fields"><a class="link" href="#constraints-examples-fields">Field description example</a></h5>
+<h5 id="constraints-examples-fields"><a class="link" href="#constraints-examples-fields">Field description example</a></h5>
 <div class="listingblock secondary">
 <div class="title">Code</div>
 <div class="content">
@@ -1068,7 +1131,7 @@ private String field;</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock">field</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-    <td class="tableblock halign-left valign-top"><p class="tableblock">EN: Must be one of [big, small]</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">EN: Must be one of [big, small]</p></td>
 </tr>
 </tbody>
 </table>
@@ -1078,12 +1141,12 @@ private String field;</code></pre>
 </div>
 </div>
 <div class="sect1">
-    <h2 id="contributing"><a class="link" href="#contributing">Contributing</a></h2>
+<h2 id="contributing"><a class="link" href="#contributing">Contributing</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-    <h3 id="contributing-building"><a class="link" href="#contributing-building">Building from source</a></h3>
+<h3 id="contributing-building"><a class="link" href="#contributing-building">Building from source</a></h3>
 <div class="sect3">
-    <h4 id="contributing-building-testjar"><a class="link" href="#contributing-building-testjar">Get spring-restdocs-core test JAR</a></h4>
+<h4 id="contributing-building-testjar"><a class="link" href="#contributing-building-testjar">Get spring-restdocs-core test JAR</a></h4>
 <div class="paragraph">
 <p>The test JAR is not published, but this project relies on it.
 If you want to build this project yourself, you first have to build and copy the test JAR on your system.</p>
@@ -1092,7 +1155,7 @@ If you want to build this project yourself, you first have to build and copy the
 <p>We use version 1.1.2.RELEASE of Spring REST Docs in this example.</p>
 </div>
 <div class="paragraph">
-    <p>You find the currently required version in <code>pom.xml</code>:</p>
+<p>You find the currently required version in <code>pom.xml</code>:</p>
 </div>
 <div class="listingblock secondary">
 <div class="title">Maven</div>
@@ -1128,7 +1191,7 @@ so that the test JAR is available to Maven.</p>
 </div>
 </div>
 <div class="sect3">
-    <h4 id="contributing-building-build"><a class="link" href="#contributing-building-build">Build</a></h4>
+<h4 id="contributing-building-build"><a class="link" href="#contributing-building-build">Build</a></h4>
 <div class="listingblock secondary">
 <div class="title">Bash (in root folder)</div>
 <div class="content">
@@ -1142,7 +1205,7 @@ so that the test JAR is available to Maven.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-    Last updated 2017-02-01 18:44:02 CET
+Last updated 2017-02-05 17:41:05 CET
 </div>
 </div>
 <link rel="stylesheet" href="highlight/styles/github.min.css">

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/javadoc/JavadocReaderImpl.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/javadoc/JavadocReaderImpl.java
@@ -66,12 +66,12 @@ public class JavadocReaderImpl implements JavadocReader {
         }
 
         try {
-            File docSource = makeRelativeToConfiguredJavaDocJsonDir(new File(fileName));
+            File docSource = makeRelativeToConfiguredJavadocJsonDir(new File(fileName));
             classJavadoc = mapper
                     .readerFor(ClassJavadoc.class)
                     .readValue(docSource);
         } catch (FileNotFoundException e) {
-            log.warn("No JavaDoc found for {} at {}", clazz.getCanonicalName(), fileName);
+            log.warn("No Javadoc found for {} at {}", clazz.getCanonicalName(), fileName);
             classJavadoc = new ClassJavadoc();
         } catch (IOException e) {
             log.error("Problem reading file {}", fileName, e);
@@ -98,7 +98,7 @@ public class JavadocReaderImpl implements JavadocReader {
         return getClass(javaBaseClass).getMethodParameterComment(javaMethodName, javaParameterName);
     }
 
-    private File makeRelativeToConfiguredJavaDocJsonDir(File outputFile) {
+    private File makeRelativeToConfiguredJavadocJsonDir(File outputFile) {
         if (javadocJsonDir != null) {
             return new File(javadocJsonDir, outputFile.getPath());
         }

--- a/spring-auto-restdocs-docs/getting-started.adoc
+++ b/spring-auto-restdocs-docs/getting-started.adoc
@@ -15,25 +15,36 @@ Spring Auto REST Docs has the following minimum requirements:
 
 . Setup project for http://docs.spring.io/spring-restdocs/docs/${spring-restdocs.version}/reference/html5/#getting-started[Spring REST Docs]
 
-. Configure maven dependency:
+. Additional configuration for this extension:
 +
-[source,xml,indent=0,role="secondary"]
+[source,xml,indent=0,subs="verbatim,attributes",role="primary"]
+.Maven
 ----
 <dependency>
     <groupId>capital.scalable</groupId>
     <artifactId>spring-auto-restdocs-core</artifactId>
     <version>1.0.5</version>
-    <scope>test</scope>
+    <scope>test</scope> <1>
 </dependency>
-----
 
-. Configure Maven JavaDoc plugin:
-+
-[source,xml,indent=0,role="secondary"]
-----
 <build>
     <plugins>
-        ...
+        <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+             <configuration>
+                <includes>
+                    <include>**/*Test.java</include>
+                </includes>
+                <systemPropertyVariables>
+                    <org.springframework.restdocs.outputDir>
+                        \${snippetsDirectory}
+                    </org.springframework.restdocs.outputDir>
+                    <org.springframework.restdocs.javadocJsonDir>
+                        \${project.build.directory}/generated-javadoc-json
+                    </org.springframework.restdocs.javadocJsonDir>
+                </systemPropertyVariables>
+             </configuration>
+        </plugin>
         <plugin>
             <artifactId>maven-javadoc-plugin</artifactId>
             <extensions>true</extensions>
@@ -62,6 +73,45 @@ Spring Auto REST Docs has the following minimum requirements:
     </plugins>
 </build>
 ----
+<1> Has to be removed if `@RestdocsNotExpanded` is used.
++
+[source,groovy,indent=0,subs="verbatim,attributes",role="secondary"]
+.Gradle
+----
+configurations {
+    jsondoclet
+}
+
+ext {
+    javadocJsonDir = file("$buildDir/generated-javadoc-json")
+}
+
+dependencies {
+    testCompile group: 'capital.scalable', name: 'spring-auto-restdocs-core', version: '1.0.5' <1>
+    jsondoclet group: 'capital.scalable', name: 'spring-auto-restdocs-json-doclet', version: '1.0.5'
+}
+
+task jsonDoclet(type: Javadoc, dependsOn: compileJava) {
+    source = sourceSets.main.allJava
+    classpath = sourceSets.main.compileClasspath
+    destinationDir = javadocJsonDir
+    options.docletpath = configurations.jsondoclet.files.asType(List)
+    options.doclet = 'capital.scalable.restdocs.jsondoclet.ExtractDocumentationAsJsonDoclet'
+    options.memberLevel = JavadocMemberLevel.PACKAGE
+}
+
+test {
+    systemProperty 'org.springframework.restdocs.outputDir', snippetsDir
+    systemProperty 'org.springframework.restdocs.javadocJsonDir', javadocJsonDir
+
+    dependsOn jsonDoclet
+}
+
+jar {
+    dependsOn asciidoctor
+}
+----
+<1> Has to be `compile` instead of `testCompile` if `@RestdocsNotExpanded` is used.
 
 . Configure MockMvc
 +

--- a/spring-auto-restdocs-docs/index.adoc
+++ b/spring-auto-restdocs-docs/index.adoc
@@ -19,12 +19,12 @@ to the code increases the maintainability of the documentation.
 
 In Spring REST Docs you have to add the documentation for your JSON with
 a DSL in your test. We moved this documentation to the POJO that represents
-your JSON object. You just add JavaDoc to the fields and it will end
+your JSON object. You just add Javadoc to the fields and it will end
 up in the documentation.
 
 Features:
 
-* Jackson visitor that gathers the whole JSON structure and includes JavaDoc
+* Jackson visitor that gathers the whole JSON structure and includes Javadoc
 and constraint annotations on the fields. It works for both request and
 response bodies. In addition to the constraint documentation support that
 is already Spring REST Docs, we automatically include the constraint message

--- a/spring-auto-restdocs-docs/section-snippet.adoc
+++ b/spring-auto-restdocs-docs/section-snippet.adoc
@@ -3,7 +3,7 @@
 
 The section snippet combines all snippets in this REST Docs extensions and also includes unmodified snippets from Spring REST Docs.
 It helps you being even more lazy, because a single line of AsciiDoc is sufficient to document one endpoint.
-Assuming of course that you already documented your code with JavaDoc.
+Assuming of course that you already documented your code with Javadoc.
 
 .Asciidoc
 [source,asciidoc,indent=0,role="secondary"]
@@ -35,7 +35,7 @@ include::../../../spring-auto-restdocs-core/src/main/resources/org/springframewo
 
 | description.adoc
 | Get an item by its ID.
-| `DescriptionSnippet` reads the JavaDoc on the method.
+| `DescriptionSnippet` reads the Javadoc on the method.
 
 | authorization.adoc
 | Resource is public.
@@ -43,19 +43,19 @@ include::../../../spring-auto-restdocs-core/src/main/resources/org/springframewo
 
 | path-parameters.adoc
 | -
-| `PathParametersSnippet` automatically lists parameters in the path including their type, whether they are optional, and their JavaDoc.
+| `PathParametersSnippet` automatically lists parameters in the path including their type, whether they are optional, and their Javadoc.
 
 | request-parameters.adoc
 | -
-| `RequestParametersSnippet` automatically lists query parameters including their type, whether they are optional, and their JavaDoc.
+| `RequestParametersSnippet` automatically lists query parameters including their type, whether they are optional, and their Javadoc.
 
 | request-fields.adoc
 | -
-| `JacksonRequestFieldSnippet` automatically lists all fields of the request body including their type, whether they are optional, and their JavaDoc.
+| `JacksonRequestFieldSnippet` automatically lists all fields of the request body including their type, whether they are optional, and their Javadoc.
 
 | response-fields.adoc
 | -
-| `JacksonResponseFieldSnippet` automatically lists all fields of the response body including their type, whether they are optional, and their JavaDoc.
+| `JacksonResponseFieldSnippet` automatically lists all fields of the response body including their type, whether they are optional, and their Javadoc.
 
 | curl-request.adoc
 | -

--- a/spring-auto-restdocs-docs/snippets.adoc
+++ b/spring-auto-restdocs-docs/snippets.adoc
@@ -25,7 +25,7 @@ protected RequestPostProcessor userToken() {
 [[snippets-path-parameters]]
 === Path parameter snippet
 
-The path parameter snippet automatically lists parameters in the path including their type, whether they are optional, and their JavaDoc.
+The path parameter snippet automatically lists parameters in the path including their type, whether they are optional, and their Javadoc.
 
 .Code
 [source,java,indent=0,role="secondary"]
@@ -50,7 +50,7 @@ public ItemResponse getItem(@PathVariable("id") String id) {
 [[snippets-request-parameters]]
 === Request parameter snippet
 
-The request parameter snippet automatically lists query parameters including their type, whether they are optional, and their JavaDoc.
+The request parameter snippet automatically lists query parameters including their type, whether they are optional, and their Javadoc.
 
 .Code
 [source,java,indent=0,role="secondary"]

--- a/spring-auto-restdocs-example/build.gradle
+++ b/spring-auto-restdocs-example/build.gradle
@@ -64,7 +64,7 @@ task jsonDoclet(type: Javadoc, dependsOn: compileJava) {
     destinationDir = javadocJsonDir
     options.docletpath = configurations.jsondoclet.files.asType(List)
     options.doclet = 'capital.scalable.restdocs.jsondoclet.ExtractDocumentationAsJsonDoclet'
-    options.memberLevel = JavadocMemberLevel.PRIVATE
+    options.memberLevel = JavadocMemberLevel.PACKAGE
 }
 
 test {

--- a/spring-auto-restdocs-example/generated-docs/index.html
+++ b/spring-auto-restdocs-example/generated-docs/index.html
@@ -442,8 +442,8 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#resources-items-add">2.3. Add an item</a></li>
 <li><a href="#resources-items-update">2.4. Update an item</a></li>
 <li><a href="#resources-items-delete">2.5. Delete an item</a></li>
-    <li><a href="#resources-item-resource-test-get-child-item">2.6. Get Child</a></li>
-    <li><a href="#resources-item-resource-test-search">2.7. Search Item</a></li>
+<li><a href="#resources-item-resource-test-get-child-item">2.6. Get Child</a></li>
+<li><a href="#resources-item-resource-test-search">2.7. Search Item</a></li>
 </ul>
 </li>
 </ul>
@@ -604,13 +604,13 @@ switch directions, e.g. <code>?sort=firstname&amp;sort=lastname,asc</code>.</p><
 <div class="sect3">
 <h4 id="_authorization"><a class="anchor" href="#_authorization"></a>2.1.1. Authorization</h4>
 <div class="paragraph">
-    <p>Resource is public.</p>
+<p>Resource is public.</p>
 </div>
 </div>
 <div class="sect3">
 <h4 id="_request_structure"><a class="anchor" href="#_request_structure"></a>2.1.2. Request structure</h4>
 <div class="paragraph">
-    <p>No request body.</p>
+<p>No request body.</p>
 </div>
 <div class="paragraph">
 <p>We do not have to care whether to include a snippet or not,
@@ -619,112 +619,112 @@ because the template returns "No data." instead of an empty table.</p>
 </div>
 <div class="sect3">
 <h4 id="_response_structure"><a class="anchor" href="#_response_structure"></a>2.1.3. Response structure</h4>
-    <table class="tableblock frame-all grid-all spread">
-        <colgroup>
-            <col style="width: 25%;">
-            <col style="width: 25%;">
-            <col style="width: 25%;">
-            <col style="width: 25%;">
-        </colgroup>
-        <thead>
-        <tr>
-            <th class="tableblock halign-left valign-top">Path</th>
-            <th class="tableblock halign-left valign-top">Type</th>
-            <th class="tableblock halign-left valign-top">Optional</th>
-            <th class="tableblock halign-left valign-top">Description</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">id</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Unique ID. This text comes directly from JavaDoc.</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">custom1</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 1</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">custom2</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 2</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">attributes</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Object</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Item attributes.</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.text</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.<br>
-                Size must be between 2 and 20 inclusive</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.number</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.<br>
-                Must be at least 1<br>
-                Must be at most 10</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.bool</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Boolean attribute.</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.decimal</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.<br>
-                Must be at least 1<br>
-                Must be at most 10</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.amount</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Amount attribute.</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.enumType</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.<br>
-                Must be one of [ONE, TWO]</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">children</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Array</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Child items (recursive). Same structure as this response.</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">description</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.</p></td>
-        </tr>
-        </tbody>
-    </table>
+<table class="tableblock frame-all grid-all spread">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">id</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Unique ID. This text comes directly from Javadoc.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">custom1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">custom2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 2</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Object</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Item attributes.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes.text</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.<br>
+Size must be between 2 and 20 inclusive</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes.number</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.<br>
+Must be at least 1<br>
+Must be at most 10</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes.bool</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean attribute.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes.decimal</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Decimal</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.<br>
+Must be at least 1<br>
+Must be at most 10</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes.amount</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Amount attribute.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes.enumType</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.<br>
+Must be one of [ONE, TWO]</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">children</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Array</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Child items (recursive). Same structure as this response.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">description</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 <div class="sect3">
 <h4 id="_example_request_response"><a class="anchor" href="#_example_request_response"></a>2.1.4. Example request/response</h4>
-    <div class="listingblock">
-        <div class="content">
-            <pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i</code></pre>
-        </div>
-    </div>
-    <div class="listingblock">
-        <div class="content">
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
 X-Content-Type-Options: nosniff
@@ -755,7 +755,7 @@ Content-Length: 378
   } ],
   "description" : "main item"
 }</code></pre>
-        </div>
+</div>
 </div>
 </div>
 </div>
@@ -773,126 +773,126 @@ Content-Length: 378
 <div class="sect3">
 <h4 id="_authorization_2"><a class="anchor" href="#_authorization_2"></a>2.2.1. Authorization</h4>
 <div class="paragraph">
-    <p>Resource is public.</p>
+<p>Resource is public.</p>
 </div>
 </div>
 <div class="sect3">
 <h4 id="_request_structure_2"><a class="anchor" href="#_request_structure_2"></a>2.2.2. Request structure</h4>
 <div class="paragraph">
-    <p>No request body.</p>
+<p>No request body.</p>
 </div>
 </div>
 <div class="sect3">
 <h4 id="_response_structure_2"><a class="anchor" href="#_response_structure_2"></a>2.2.3. Response structure</h4>
-    <table class="tableblock frame-all grid-all spread">
-        <colgroup>
-            <col style="width: 25%;">
-            <col style="width: 25%;">
-            <col style="width: 25%;">
-            <col style="width: 25%;">
-        </colgroup>
-        <thead>
-        <tr>
-            <th class="tableblock halign-left valign-top">Path</th>
-            <th class="tableblock halign-left valign-top">Type</th>
-            <th class="tableblock halign-left valign-top">Optional</th>
-            <th class="tableblock halign-left valign-top">Description</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">[].id</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Unique ID. This text comes directly from JavaDoc.</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">[].custom1</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 1</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">[].custom2</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 2</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Object</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Item attributes.</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.text</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.<br>
-                Size must be between 2 and 20 inclusive</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.number</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.<br>
-                Must be at least 1<br>
-                Must be at most 10</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.bool</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Boolean attribute.</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.decimal</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.<br>
-                Must be at least 1<br>
-                Must be at most 10</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.amount</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Amount attribute.</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.enumType</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.<br>
-                Must be one of [ONE, TWO]</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">[].children</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Array</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Child items (recursive). Same structure as this response.</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">[].description</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.</p></td>
-        </tr>
-        </tbody>
-    </table>
+<table class="tableblock frame-all grid-all spread">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].id</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Unique ID. This text comes directly from Javadoc.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].custom1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].custom2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 2</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Object</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Item attributes.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.text</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.<br>
+Size must be between 2 and 20 inclusive</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.number</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.<br>
+Must be at least 1<br>
+Must be at most 10</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.bool</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean attribute.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.decimal</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Decimal</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.<br>
+Must be at least 1<br>
+Must be at most 10</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.amount</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Amount attribute.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.enumType</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.<br>
+Must be one of [ONE, TWO]</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].children</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Array</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Child items (recursive). Same structure as this response.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].description</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 <div class="sect3">
 <h4 id="_example_request_response_2"><a class="anchor" href="#_example_request_response_2"></a>2.2.4. Example request/response</h4>
-    <div class="listingblock">
-        <div class="content">
-            <pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items' -i</code></pre>
-        </div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items' -i</code></pre>
+</div>
 </div>
 <div class="paragraph">
 <p>The array shortening feature intercepted here and reduced the 100 items to 3.</p>
 </div>
-    <div class="listingblock">
-        <div class="content">
+<div class="listingblock">
+<div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
 X-Content-Type-Options: nosniff
@@ -928,7 +928,7 @@ Content-Length: 483
   "children" : null,
   "description" : "first child"
 } ]</code></pre>
-        </div>
+</div>
 </div>
 </div>
 </div>
@@ -940,64 +940,64 @@ Content-Length: 483
 <div class="sect3">
 <h4 id="_authorization_3"><a class="anchor" href="#_authorization_3"></a>2.3.1. Authorization</h4>
 <div class="paragraph">
-    <p>User access token required.</p>
+<p>User access token required.</p>
 </div>
 </div>
 <div class="sect3">
 <h4 id="_request_structure_3"><a class="anchor" href="#_request_structure_3"></a>2.3.2. Request structure</h4>
-    <table class="tableblock frame-all grid-all spread">
-        <colgroup>
-            <col style="width: 25%;">
-            <col style="width: 25%;">
-            <col style="width: 25%;">
-            <col style="width: 25%;">
-        </colgroup>
-        <thead>
-        <tr>
-            <th class="tableblock halign-left valign-top">Path</th>
-            <th class="tableblock halign-left valign-top">Type</th>
-            <th class="tableblock halign-left valign-top">Optional</th>
-            <th class="tableblock halign-left valign-top">Description</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">description</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">true<br>
-                EN: false</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.<br>
-                DE: Size must be between 2 and 10 inclusive<br>
-                EN: Size must be between 4 and 12 inclusive<br>
-                Length must be between 0 and 20 inclusive</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Country dependent type of the item.<br>
-                DE: Must be one of [klein, groß]<br>
-                EN: Must be one of [small, big]<br>
-                Size must be between 0 and 1000 inclusive</p></td>
-        </tr>
-        </tbody>
-    </table>
+<table class="tableblock frame-all grid-all spread">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">description</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true<br>
+EN: false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.<br>
+DE: Size must be between 2 and 10 inclusive<br>
+EN: Size must be between 4 and 12 inclusive<br>
+Length must be between 0 and 20 inclusive</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Country dependent type of the item.<br>
+DE: Must be one of [klein, groß]<br>
+EN: Must be one of [small, big]<br>
+Size must be between 0 and 1000 inclusive</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 <div class="sect3">
 <h4 id="_response_structure_3"><a class="anchor" href="#_response_structure_3"></a>2.3.3. Response structure</h4>
 <div class="paragraph">
-    <p>No response body.</p>
+<p>No response body.</p>
 </div>
 </div>
 <div class="sect3">
 <h4 id="_example_request_response_3"><a class="anchor" href="#_example_request_response_3"></a>2.3.4. Example request/response</h4>
-    <div class="listingblock">
-        <div class="content">
-            <pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items' -i -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer f7ee64f0-bc19-4651-8c7c-929ffebc5ce4' -d '{"description":"Hot News"}'</code></pre>
-        </div>
-    </div>
-    <div class="listingblock">
-        <div class="content">
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items' -i -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer 68ab515a-4791-4b9d-b12a-ad79d47847a5' -d '{"description":"Hot News"}'</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 201 Created
 Location: /items/2
 X-Content-Type-Options: nosniff
@@ -1006,7 +1006,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY</code></pre>
-        </div>
+</div>
 </div>
 </div>
 </div>
@@ -1018,157 +1018,157 @@ X-Frame-Options: DENY</code></pre>
 <div class="sect3">
 <h4 id="_authorization_4"><a class="anchor" href="#_authorization_4"></a>2.4.1. Authorization</h4>
 <div class="paragraph">
-    <p>User access token required.</p>
+<p>User access token required.</p>
 </div>
 </div>
 <div class="sect3">
 <h4 id="_request_structure_4"><a class="anchor" href="#_request_structure_4"></a>2.4.2. Request structure</h4>
-    <table class="tableblock frame-all grid-all spread">
-        <colgroup>
-            <col style="width: 25%;">
-            <col style="width: 25%;">
-            <col style="width: 25%;">
-            <col style="width: 25%;">
-        </colgroup>
-        <thead>
-        <tr>
-            <th class="tableblock halign-left valign-top">Path</th>
-            <th class="tableblock halign-left valign-top">Type</th>
-            <th class="tableblock halign-left valign-top">Optional</th>
-            <th class="tableblock halign-left valign-top">Description</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">description</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">true<br>
-                EN: false</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.<br>
-                DE: Size must be between 2 and 10 inclusive<br>
-                EN: Size must be between 4 and 12 inclusive<br>
-                Length must be between 0 and 20 inclusive</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Country dependent type of the item.<br>
-                DE: Must be one of [klein, groß]<br>
-                EN: Must be one of [small, big]<br>
-                Size must be between 0 and 1000 inclusive</p></td>
-        </tr>
-        </tbody>
-    </table>
+<table class="tableblock frame-all grid-all spread">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">description</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true<br>
+EN: false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.<br>
+DE: Size must be between 2 and 10 inclusive<br>
+EN: Size must be between 4 and 12 inclusive<br>
+Length must be between 0 and 20 inclusive</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Country dependent type of the item.<br>
+DE: Must be one of [klein, groß]<br>
+EN: Must be one of [small, big]<br>
+Size must be between 0 and 1000 inclusive</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 <div class="sect3">
 <h4 id="_response_structure_4"><a class="anchor" href="#_response_structure_4"></a>2.4.3. Response structure</h4>
-    <table class="tableblock frame-all grid-all spread">
-        <colgroup>
-            <col style="width: 25%;">
-            <col style="width: 25%;">
-            <col style="width: 25%;">
-            <col style="width: 25%;">
-        </colgroup>
-        <thead>
-        <tr>
-            <th class="tableblock halign-left valign-top">Path</th>
-            <th class="tableblock halign-left valign-top">Type</th>
-            <th class="tableblock halign-left valign-top">Optional</th>
-            <th class="tableblock halign-left valign-top">Description</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">id</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Unique ID. This text comes directly from JavaDoc.</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">custom1</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 1</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">custom2</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 2</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">attributes</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Object</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Item attributes.</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.text</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.<br>
-                Size must be between 2 and 20 inclusive</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.number</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.<br>
-                Must be at least 1<br>
-                Must be at most 10</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.bool</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Boolean attribute.</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.decimal</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.<br>
-                Must be at least 1<br>
-                Must be at most 10</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.amount</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Amount attribute.</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.enumType</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.<br>
-                Must be one of [ONE, TWO]</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">children</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Array</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Child items (recursive). Same structure as this response.</p></td>
-        </tr>
-        <tr>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">description</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.</p></td>
-        </tr>
-        </tbody>
-    </table>
+<table class="tableblock frame-all grid-all spread">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">id</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Unique ID. This text comes directly from Javadoc.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">custom1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">custom2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 2</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Object</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Item attributes.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes.text</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.<br>
+Size must be between 2 and 20 inclusive</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes.number</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.<br>
+Must be at least 1<br>
+Must be at most 10</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes.bool</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean attribute.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes.decimal</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Decimal</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.<br>
+Must be at least 1<br>
+Must be at most 10</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes.amount</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Amount attribute.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes.enumType</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.<br>
+Must be one of [ONE, TWO]</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">children</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Array</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Child items (recursive). Same structure as this response.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">description</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 <div class="sect3">
 <h4 id="_example_request_response_4"><a class="anchor" href="#_example_request_response_4"></a>2.4.4. Example request/response</h4>
-    <div class="listingblock">
-        <div class="content">
-            <pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X PUT -H 'Content-Type: application/json' -H 'Authorization: Bearer f7ee64f0-bc19-4651-8c7c-929ffebc5ce4' -d '{"description":"Hot News"}'</code></pre>
-        </div>
-    </div>
-    <div class="listingblock">
-        <div class="content">
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X PUT -H 'Content-Type: application/json' -H 'Authorization: Bearer 68ab515a-4791-4b9d-b12a-ad79d47847a5' -d '{"description":"Hot News"}'</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
 X-Content-Type-Options: nosniff
@@ -1185,7 +1185,7 @@ Content-Length: 90
   "children" : null,
   "description" : "Hot News"
 }</code></pre>
-        </div>
+</div>
 </div>
 </div>
 </div>
@@ -1197,31 +1197,30 @@ Content-Length: 90
 <div class="sect3">
 <h4 id="_authorization_5"><a class="anchor" href="#_authorization_5"></a>2.5.1. Authorization</h4>
 <div class="paragraph">
-    <p>User access token required.</p>
+<p>User access token required.</p>
 </div>
 </div>
 <div class="sect3">
 <h4 id="_request_structure_5"><a class="anchor" href="#_request_structure_5"></a>2.5.2. Request structure</h4>
 <div class="paragraph">
-    <p>No request body.</p>
+<p>No request body.</p>
 </div>
 </div>
 <div class="sect3">
 <h4 id="_response_structure_5"><a class="anchor" href="#_response_structure_5"></a>2.5.3. Response structure</h4>
 <div class="paragraph">
-    <p>No response body.</p>
+<p>No response body.</p>
 </div>
 </div>
 <div class="sect3">
 <h4 id="_example_request_response_5"><a class="anchor" href="#_example_request_response_5"></a>2.5.4. Example request/response</h4>
-    <div class="listingblock">
-        <div class="content">
-  <pre class="highlightjs highlight"><code class="language-bash"
-                                           data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X DELETE -H 'Authorization: Bearer f7ee64f0-bc19-4651-8c7c-929ffebc5ce4'</code></pre>
-        </div>
-    </div>
-    <div class="listingblock">
-        <div class="content">
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X DELETE -H 'Authorization: Bearer 68ab515a-4791-4b9d-b12a-ad79d47847a5'</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
 X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
@@ -1229,177 +1228,177 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY</code></pre>
-        </div>
-    </div>
 </div>
 </div>
-    <div class="sect2">
-        <h3 id="resources-item-resource-test-get-child-item"><a class="anchor" href="#resources-item-resource-test-get-child-item"></a>2.6. Get Child</h3>
+</div>
+</div>
+<div class="sect2">
+<h3 id="resources-item-resource-test-get-child-item"><a class="anchor" href="#resources-item-resource-test-get-child-item"></a>2.6. Get Child</h3>
 <div class="paragraph">
-    <p><code>GET /items/{id}/{child}</code></p>
+<p><code>GET /items/{id}/{child}</code></p>
 </div>
 <div class="paragraph">
-    <p>Retrieves a child of specified item.</p>
+<p>Retrieves a child of specified item.</p>
 </div>
-        <div class="sect3">
-            <h4 id="_authorization_6"><a class="anchor" href="#_authorization_6"></a>2.6.1. Authorization</h4>
-            <div class="paragraph">
-                <p>Resource is public.</p>
-            </div>
-        </div>
-        <div class="sect3">
-            <h4 id="_path_parameters"><a class="anchor" href="#_path_parameters"></a>2.6.2. Path parameters</h4>
-            <table class="tableblock frame-all grid-all spread">
-                <colgroup>
-                    <col style="width: 25%;">
-                    <col style="width: 25%;">
-                    <col style="width: 25%;">
-                    <col style="width: 25%;">
-                </colgroup>
-                <thead>
-                <tr>
-                    <th class="tableblock halign-left valign-top">Parameter</th>
-                    <th class="tableblock halign-left valign-top">Type</th>
-                    <th class="tableblock halign-left valign-top">Optional</th>
-                    <th class="tableblock halign-left valign-top">Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">id</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Item ID.</p></td>
-                </tr>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">child</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Child ID.</p></td>
-                </tr>
-                </tbody>
-            </table>
-        </div>
-        <div class="sect3">
-            <h4 id="_query_parameters"><a class="anchor" href="#_query_parameters"></a>2.6.3. Query parameters</h4>
-            <div class="paragraph">
-                <p>No parameters.</p>
-            </div>
-        </div>
-        <div class="sect3">
-            <h4 id="_request_structure_6"><a class="anchor" href="#_request_structure_6"></a>2.6.4. Request structure</h4>
-            <div class="paragraph">
-                <p>No request body.</p>
-            </div>
-        </div>
-        <div class="sect3">
-            <h4 id="_response_structure_6"><a class="anchor" href="#_response_structure_6"></a>2.6.5. Response structure</h4>
-            <table class="tableblock frame-all grid-all spread">
-                <colgroup>
-                    <col style="width: 25%;">
-                    <col style="width: 25%;">
-                    <col style="width: 25%;">
-                    <col style="width: 25%;">
-                </colgroup>
-                <thead>
-                <tr>
-                    <th class="tableblock halign-left valign-top">Path</th>
-                    <th class="tableblock halign-left valign-top">Type</th>
-                    <th class="tableblock halign-left valign-top">Optional</th>
-                    <th class="tableblock halign-left valign-top">Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">id</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Unique ID. This text comes directly from JavaDoc.</p></td>
-                </tr>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">custom1</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 1</p></td>
-                </tr>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">custom2</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 2</p></td>
-                </tr>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">attributes</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Object</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Item attributes.</p></td>
-                </tr>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.text</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.<br>
-                        Size must be between 2 and 20 inclusive</p></td>
-                </tr>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.number</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.<br>
-                        Must be at least 1<br>
-                        Must be at most 10</p></td>
-                </tr>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.bool</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Boolean attribute.</p></td>
-                </tr>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.decimal</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.<br>
-                        Must be at least 1<br>
-                        Must be at most 10</p></td>
-                </tr>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.amount</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Amount attribute.</p></td>
-                </tr>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.enumType</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.<br>
-                        Must be one of [ONE, TWO]</p></td>
-                </tr>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">children</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Array</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Child items (recursive). Same structure as this response.</p></td>
-                </tr>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">description</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.</p></td>
-                </tr>
-                </tbody>
-            </table>
-        </div>
-        <div class="sect3">
-            <h4 id="_example_request_response_6"><a class="anchor" href="#_example_request_response_6"></a>2.6.6. Example request/response</h4>
-            <div class="listingblock">
-                <div class="content">
-                    <pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items/1/child-1' -i</code></pre>
-                </div>
-            </div>
-            <div class="listingblock">
-                <div class="content">
+<div class="sect3">
+<h4 id="_authorization_6"><a class="anchor" href="#_authorization_6"></a>2.6.1. Authorization</h4>
+<div class="paragraph">
+<p>Resource is public.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_path_parameters"><a class="anchor" href="#_path_parameters"></a>2.6.2. Path parameters</h4>
+<table class="tableblock frame-all grid-all spread">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">id</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Item ID.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">child</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Child ID.</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_query_parameters"><a class="anchor" href="#_query_parameters"></a>2.6.3. Query parameters</h4>
+<div class="paragraph">
+<p>No parameters.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_request_structure_6"><a class="anchor" href="#_request_structure_6"></a>2.6.4. Request structure</h4>
+<div class="paragraph">
+<p>No request body.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_structure_6"><a class="anchor" href="#_response_structure_6"></a>2.6.5. Response structure</h4>
+<table class="tableblock frame-all grid-all spread">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">id</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Unique ID. This text comes directly from Javadoc.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">custom1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">custom2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 2</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Object</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Item attributes.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes.text</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.<br>
+Size must be between 2 and 20 inclusive</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes.number</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.<br>
+Must be at least 1<br>
+Must be at most 10</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes.bool</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean attribute.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes.decimal</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Decimal</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.<br>
+Must be at least 1<br>
+Must be at most 10</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes.amount</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Amount attribute.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes.enumType</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.<br>
+Must be one of [ONE, TWO]</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">children</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Array</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Child items (recursive). Same structure as this response.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">description</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_example_request_response_6"><a class="anchor" href="#_example_request_response_6"></a>2.6.6. Example request/response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items/1/child-1' -i</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
 X-Content-Type-Options: nosniff
@@ -1416,181 +1415,180 @@ Content-Length: 99
   "children" : null,
   "description" : "first child"
 }</code></pre>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="sect2">
-        <h3 id="resources-item-resource-test-search"><a class="anchor" href="#resources-item-resource-test-search"></a>2.7. Search Item</h3>
-        <div class="paragraph">
-            <p><code>GET /items/search</code></p>
-        </div>
-        <div class="paragraph">
-            <p>Searches for item based on lookup parameters.</p>
-        </div>
-        <div class="sect3">
-            <h4 id="_authorization_7"><a class="anchor" href="#_authorization_7"></a>2.7.1. Authorization</h4>
-            <div class="paragraph">
-                <p>Resource is public.</p>
-            </div>
-        </div>
-        <div class="sect3">
-            <h4 id="_path_parameters_2"><a class="anchor" href="#_path_parameters_2"></a>2.7.2. Path parameters</h4>
-            <div class="paragraph">
-                <p>No parameters.</p>
-            </div>
-        </div>
-        <div class="sect3">
-            <h4 id="_query_parameters_2"><a class="anchor" href="#_query_parameters_2"></a>2.7.3. Query parameters</h4>
-            <table class="tableblock frame-all grid-all spread">
-                <colgroup>
-                    <col style="width: 25%;">
-                    <col style="width: 25%;">
-                    <col style="width: 25%;">
-                    <col style="width: 25%;">
-                </colgroup>
-                <thead>
-                <tr>
-                    <th class="tableblock halign-left valign-top">Parameter</th>
-                    <th class="tableblock halign-left valign-top">Type</th>
-                    <th class="tableblock halign-left valign-top">Optional</th>
-                    <th class="tableblock halign-left valign-top">Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">desc</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Lookup on description field.</p></td>
-                </tr>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">hint</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Lookup hint.</p></td>
-                </tr>
-                </tbody>
-            </table>
-        </div>
-        <div class="sect3">
-            <h4 id="_request_structure_7"><a class="anchor" href="#_request_structure_7"></a>2.7.4. Request structure</h4>
-            <div class="paragraph">
-                <p>No request body.</p>
-            </div>
-        </div>
-        <div class="sect3">
-            <h4 id="_response_structure_7"><a class="anchor" href="#_response_structure_7"></a>2.7.5. Response structure</h4>
-            <div class="paragraph">
-                <p>Standard <a href="#overview-pagination">paging</a> response where <code>content</code> field is list of following objects:</p>
-            </div>
-            <table class="tableblock frame-all grid-all spread">
-                <colgroup>
-                    <col style="width: 25%;">
-                    <col style="width: 25%;">
-                    <col style="width: 25%;">
-                    <col style="width: 25%;">
-                </colgroup>
-                <thead>
-                <tr>
-                    <th class="tableblock halign-left valign-top">Path</th>
-                    <th class="tableblock halign-left valign-top">Type</th>
-                    <th class="tableblock halign-left valign-top">Optional</th>
-                    <th class="tableblock halign-left valign-top">Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">id</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Unique ID. This text comes directly from JavaDoc.</p></td>
-                </tr>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">custom1</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 1</p></td>
-                </tr>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">custom2</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 2</p></td>
-                </tr>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">attributes</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Object</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Item attributes.</p></td>
-                </tr>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.text</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.<br>
-                        Size must be between 2 and 20 inclusive</p></td>
-                </tr>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.number</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.<br>
-                        Must be at least 1<br>
-                        Must be at most 10</p></td>
-                </tr>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.bool</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Boolean attribute.</p></td>
-                </tr>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.decimal</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.<br>
-                        Must be at least 1<br>
-                        Must be at most 10</p></td>
-                </tr>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.amount</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Amount attribute.</p></td>
-                </tr>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.enumType</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.<br>
-                        Must be one of [ONE, TWO]</p></td>
-                </tr>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">children</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Array</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Child items (recursive). Same structure as this response.</p></td>
-                </tr>
-                <tr>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">description</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-                    <td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.</p></td>
-                </tr>
-                </tbody>
-            </table>
-        </div>
-        <div class="sect3">
-            <h4 id="_example_request_response_7"><a class="anchor" href="#_example_request_response_7"></a>2.7.6. Example request/response</h4>
-            <div class="listingblock">
-                <div class="content">
-                    <pre class="highlightjs highlight"><code class="language-bash"
-                                                             data-lang="bash">$ curl 'http://localhost:8080/items/search?desc=main&amp;hint=1?desc=main&amp;hint=1' -i</code></pre>
-                </div>
-            </div>
-            <div class="listingblock">
-                <div class="content">
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="resources-item-resource-test-search"><a class="anchor" href="#resources-item-resource-test-search"></a>2.7. Search Item</h3>
+<div class="paragraph">
+<p><code>GET /items/search</code></p>
+</div>
+<div class="paragraph">
+<p>Searches for item based on lookup parameters.</p>
+</div>
+<div class="sect3">
+<h4 id="_authorization_7"><a class="anchor" href="#_authorization_7"></a>2.7.1. Authorization</h4>
+<div class="paragraph">
+<p>Resource is public.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_path_parameters_2"><a class="anchor" href="#_path_parameters_2"></a>2.7.2. Path parameters</h4>
+<div class="paragraph">
+<p>No parameters.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_query_parameters_2"><a class="anchor" href="#_query_parameters_2"></a>2.7.3. Query parameters</h4>
+<table class="tableblock frame-all grid-all spread">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">desc</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Lookup on description field.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">hint</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Lookup hint.</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_request_structure_7"><a class="anchor" href="#_request_structure_7"></a>2.7.4. Request structure</h4>
+<div class="paragraph">
+<p>No request body.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_structure_7"><a class="anchor" href="#_response_structure_7"></a>2.7.5. Response structure</h4>
+<div class="paragraph">
+<p>Standard <a href="#overview-pagination">paging</a> response where <code>content</code> field is list of following objects:</p>
+</div>
+<table class="tableblock frame-all grid-all spread">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">id</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Unique ID. This text comes directly from Javadoc.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">custom1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">custom2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 2</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Object</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Item attributes.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes.text</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.<br>
+Size must be between 2 and 20 inclusive</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes.number</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.<br>
+Must be at least 1<br>
+Must be at most 10</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes.bool</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean attribute.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes.decimal</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Decimal</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.<br>
+Must be at least 1<br>
+Must be at most 10</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes.amount</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Amount attribute.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attributes.enumType</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.<br>
+Must be one of [ONE, TWO]</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">children</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Array</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Child items (recursive). Same structure as this response.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">description</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_example_request_response_7"><a class="anchor" href="#_example_request_response_7"></a>2.7.6. Example request/response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items/search?desc=main&amp;hint=1?desc=main&amp;hint=1' -i</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
 X-Content-Type-Options: nosniff
@@ -1627,13 +1625,13 @@ Content-Length: 625
   "totalPages" : 1,
   "totalElements" : 1,
   "last" : true,
-  "size" : 0,
-  "number" : 0,
   "sort" : null,
   "numberOfElements" : 1,
-  "first" : true
+  "first" : true,
+  "size" : 0,
+  "number" : 0
 }</code></pre>
-                </div>
+</div>
 </div>
 </div>
 </div>
@@ -1642,7 +1640,7 @@ Content-Length: 625
 </div>
 <div id="footer">
 <div id="footer-text">
-    Last updated 2016-11-25 17:33:45 CET
+Last updated 2016-09-12 22:19:00 CEST
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.1/styles/github.min.css">

--- a/spring-auto-restdocs-example/src/main/java/capital/scalable/restdocs/example/items/ItemResponse.java
+++ b/spring-auto-restdocs-example/src/main/java/capital/scalable/restdocs/example/items/ItemResponse.java
@@ -40,7 +40,7 @@ import org.hibernate.validator.constraints.NotEmpty;
 @AllArgsConstructor
 class ItemResponse {
     /**
-     * Unique ID. This text comes directly from JavaDoc.
+     * Unique ID. This text comes directly from Javadoc.
      */
     @NotBlank
     private String id;

--- a/spring-auto-restdocs-json-doclet/src/main/java/capital/scalable/restdocs/jsondoclet/ExtractDocumentationAsJsonDoclet.java
+++ b/spring-auto-restdocs-json-doclet/src/main/java/capital/scalable/restdocs/jsondoclet/ExtractDocumentationAsJsonDoclet.java
@@ -34,7 +34,7 @@ import com.sun.javadoc.RootDoc;
 import com.sun.tools.doclets.standard.Standard;
 
 /**
- * JavaDoc to JSON doclet.
+ * Javadoc to JSON doclet.
  */
 public class ExtractDocumentationAsJsonDoclet extends Standard {
 


### PR DESCRIPTION
Additional changes:
*  "JavaDoc" is replaced with "Javadoc". See https://en.wikipedia.org/wiki/Javadoc
* Gradle doclet member level changed from `PRIVATE` to `PACKAGE` so that it is consistent with the Maven version. Package level visibility is sufficient here.

A large part of the documentation diff is unnecessary because different systems indent differently. Might be a difference between the Mac and the Linux version, but I have not checked this yet.