### PR TITLE
Example project: use DSL to set query parameters in test

### DIFF
--- a/spring-auto-restdocs-example/src/test/java/capital/scalable/restdocs/example/items/ItemResourceTest.java
+++ b/spring-auto-restdocs-example/src/test/java/capital/scalable/restdocs/example/items/ItemResourceTest.java
@@ -98,7 +98,9 @@ public class ItemResourceTest extends MockMvcBase {
 
     @Test
     public void searchItems() throws Exception {
-        mockMvc.perform(get("/items/search?desc=main&hint=1"))
+        mockMvc.perform(get("/items/search")
+                    .param("desc", "main")
+                    .param("hint", "1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content").isArray())
                 .andExpect(jsonPath("$.content", hasSize(1)))


### PR DESCRIPTION
This PR only improves test code in the example project.

https://github.com/ScaCap/spring-auto-restdocs/pull/59 fixes the duplicate appearance of the query parameters in the cURL snippet by including Spring REST Docs 1.1.2.
Before:
```
curl 'http://localhost:8080/items/search?desc=main&hint=1?desc=main&hint=1' -i
```
After:
```
curl 'http://localhost:8080/items/search?desc=main&hint=1' -i
```