### PR TITLE
correct formatting for multiline Javadoc

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1280,7 +1280,7 @@ so that the test JAR is available to Maven.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-    Last updated 2017-02-23 14:42:01 CET
+    Last updated 2017-02-24 12:25:49 CET
 </div>
 </div>
 <link rel="stylesheet" href="highlight/styles/github.min.css">

--- a/docs/index.html
+++ b/docs/index.html
@@ -1280,7 +1280,7 @@ so that the test JAR is available to Maven.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-    Last updated 2017-02-23 14:02:55 CET
+    Last updated 2017-02-23 14:42:01 CET
 </div>
 </div>
 <link rel="stylesheet" href="highlight/styles/github.min.css">

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/OperationAttributeHelper.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/OperationAttributeHelper.java
@@ -38,12 +38,16 @@ import org.springframework.restdocs.snippet.Snippet;
 import org.springframework.restdocs.snippet.StandardWriterResolver;
 import org.springframework.restdocs.snippet.WriterResolver;
 import org.springframework.restdocs.templates.TemplateFormat;
+import org.springframework.restdocs.templates.TemplateFormats;
 import org.springframework.web.method.HandlerMethod;
 
 public class OperationAttributeHelper {
     private static final String ATTRIBUTE_NAME_CONFIGURATION =
             "org.springframework.restdocs.configuration";
     public static final String REQUEST_PATTERN = "REQUEST_PATTERN";
+
+    private static final String LINE_BREAK_ASCIIDOC = " +\n";
+    private static final String LINE_BREAK_MARKDOWN = "<br>";
 
     public static HandlerMethod getHandlerMethod(Operation operation) {
         Map<String, Object> attributes = operation.getAttributes();
@@ -125,5 +129,15 @@ public class OperationAttributeHelper {
 
     public static List<Snippet> getDefaultSnippets(Operation operation) {
         return (List<Snippet>) operation.getAttributes().get(ATTRIBUTE_NAME_DEFAULT_SNIPPETS);
+    }
+
+    public static String determineLineBreak(Operation operation) {
+        return determineLineBreak(getTemplateFormat(operation));
+    }
+
+    // necessary until https://github.com/spring-projects/spring-restdocs/issues/351 is fixed
+    public static String determineLineBreak(TemplateFormat templateFormat) {
+        return templateFormat.getId().equals(TemplateFormats.asciidoctor().getId())
+                ? LINE_BREAK_ASCIIDOC : LINE_BREAK_MARKDOWN;
     }
 }

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/javadoc/JavadocUtil.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/javadoc/JavadocUtil.java
@@ -1,0 +1,29 @@
+package capital.scalable.restdocs.javadoc;
+
+public class JavadocUtil {
+    private JavadocUtil() {
+        // util
+    }
+
+    public static String convertFromJavadoc(String javadoc, String lineBreak) {
+        String lineBreaked = javadoc
+                .replace("\n", "")
+                .replace("<br/>", "\n")
+                .replace("<br>", "\n")
+                .replace("<p>", "\n\n")
+                .replace("</p>", "")
+                .trim();
+
+        if (lineBreaked.isEmpty()) {
+            return "";
+        }
+
+        StringBuilder res = new StringBuilder();
+        for (String line : lineBreaked.split("\n")) {
+            res.append(line.trim()).append(lineBreak);
+        }
+        res.delete(res.lastIndexOf(lineBreak), res.length());
+
+        return res.toString();
+    }
+}

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/misc/DescriptionSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/misc/DescriptionSnippet.java
@@ -16,8 +16,10 @@
 
 package capital.scalable.restdocs.misc;
 
+import static capital.scalable.restdocs.OperationAttributeHelper.determineLineBreak;
 import static capital.scalable.restdocs.OperationAttributeHelper.getHandlerMethod;
 import static capital.scalable.restdocs.OperationAttributeHelper.getJavadocReader;
+import static capital.scalable.restdocs.javadoc.JavadocUtil.convertFromJavadoc;
 import static capital.scalable.restdocs.SnippetRegistry.DESCRIPTION;
 
 import java.util.HashMap;
@@ -37,7 +39,7 @@ public class DescriptionSnippet extends TemplatedSnippet {
     protected Map<String, Object> createModel(Operation operation) {
         HandlerMethod handlerMethod = getHandlerMethod(operation);
 
-        final String methodComment;
+        String methodComment;
         if (handlerMethod != null) {
             methodComment = getJavadocReader(operation)
                     .resolveMethodComment(handlerMethod.getBeanType(),
@@ -45,6 +47,8 @@ public class DescriptionSnippet extends TemplatedSnippet {
         } else {
             methodComment = "";
         }
+
+        methodComment = convertFromJavadoc(methodComment, determineLineBreak(operation));
 
         Map<String, Object> model = new HashMap<>();
         model.put("description", methodComment);

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/snippet/StandardTableSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/snippet/StandardTableSnippet.java
@@ -111,16 +111,19 @@ public abstract class StandardTableSnippet extends TemplatedSnippet {
 
     private String joinAndFormat(String lineBreak, String description, List<String> constraints) {
         StringBuilder str = new StringBuilder(description);
-        if (str.length() > 0 && str.charAt(str.length() - 1) != '.') {
+        if (!description.isEmpty() && !description.endsWith(".")) {
             str.append('.');
         }
 
         for (String constraint : constraints) {
+            if (constraint.trim().isEmpty()) {
+                continue;
+            }
             if (str.length() > 0) {
                 str.append(lineBreak);
             }
             str.append(constraint.trim());
-            if (constraint.charAt(constraint.length() - 1) != '.') {
+            if (!constraint.endsWith(".")) {
                 str.append('.');
             }
         }

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/snippet/StandardTableSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/snippet/StandardTableSnippet.java
@@ -16,13 +16,14 @@
 
 package capital.scalable.restdocs.snippet;
 
+import static capital.scalable.restdocs.OperationAttributeHelper.determineLineBreak;
 import static capital.scalable.restdocs.OperationAttributeHelper.getHandlerMethod;
-import static capital.scalable.restdocs.OperationAttributeHelper.getTemplateFormat;
 import static capital.scalable.restdocs.constraints.ConstraintReader.CONSTRAINTS_ATTRIBUTE;
 import static capital.scalable.restdocs.constraints.ConstraintReader.OPTIONAL_ATTRIBUTE;
+import static capital.scalable.restdocs.javadoc.JavadocUtil.convertFromJavadoc;
 import static java.util.Collections.emptyList;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.join;
+import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -33,13 +34,9 @@ import java.util.Map;
 import org.springframework.restdocs.operation.Operation;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.snippet.TemplatedSnippet;
-import org.springframework.restdocs.templates.TemplateFormats;
 import org.springframework.web.method.HandlerMethod;
 
 public abstract class StandardTableSnippet extends TemplatedSnippet {
-
-    private static final String LINE_BREAK_ASCIIDOC = " +\n";
-    private static final String LINE_BREAK_MARKDOWN = "<br>";
 
     protected StandardTableSnippet(String snippetName, Map<String, Object> attributes) {
         super(snippetName, attributes);
@@ -84,8 +81,8 @@ public abstract class StandardTableSnippet extends TemplatedSnippet {
     protected Map<String, Object> createModelForDescriptor(FieldDescriptor descriptor,
             String lineBreak) {
         String path = descriptor.getPath();
-        String type = stringOrEmpty(descriptor.getType());
-        String description = stringOrEmpty(descriptor.getDescription());
+        String type = toString(descriptor.getType());
+        String description = convertFromJavadoc(toString(descriptor.getDescription()), lineBreak);
 
         List<String> optionalMessages = (List<String>) descriptor.getAttributes().get(
                 OPTIONAL_ATTRIBUTE);
@@ -93,13 +90,8 @@ public abstract class StandardTableSnippet extends TemplatedSnippet {
 
         List<String> constraints = (List<String>) descriptor.getAttributes().get(
                 CONSTRAINTS_ATTRIBUTE);
-        if (constraints != null && !constraints.isEmpty()) {
-            String constraintMessages = join(constraints, lineBreak);
-            if (isNotBlank(description)) {
-                description += lineBreak;
-            }
-            description += constraintMessages;
-        }
+
+        description = joinAndFormat(lineBreak, description, constraints);
 
         Map<String, Object> model = new HashMap<>();
         model.put("path", path);
@@ -109,16 +101,30 @@ public abstract class StandardTableSnippet extends TemplatedSnippet {
         return model;
     }
 
-    private String stringOrEmpty(Object value) {
+    private String toString(Object value) {
         if (value != null) {
-            return value.toString();
+            return trimToEmpty(value.toString());
         } else {
             return "";
         }
     }
 
-    private String determineLineBreak(Operation operation) {
-        return getTemplateFormat(operation).getId().equals(TemplateFormats.asciidoctor().getId())
-                ? LINE_BREAK_ASCIIDOC : LINE_BREAK_MARKDOWN;
+    private String joinAndFormat(String lineBreak, String description, List<String> constraints) {
+        StringBuilder str = new StringBuilder(description);
+        if (str.length() > 0 && str.charAt(str.length() - 1) != '.') {
+            str.append('.');
+        }
+
+        for (String constraint : constraints) {
+            if (str.length() > 0) {
+                str.append(lineBreak);
+            }
+            str.append(constraint.trim());
+            if (constraint.charAt(constraint.length() - 1) != '.') {
+                str.append('.');
+            }
+        }
+
+        return str.toString();
     }
 }

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/javadoc/JavadocReaderImplIntegrationTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/javadoc/JavadocReaderImplIntegrationTest.java
@@ -30,7 +30,8 @@ public class JavadocReaderImplIntegrationTest {
         assertThat(comment, equalTo("Very useful field"));
 
         comment = javadocReader.resolveMethodComment(IntegrationType.class, "dummyMethod");
-        assertThat(comment, equalTo("Very useful method"));
+        // line breaks are not handled here - pure javadoc
+        assertThat(comment, equalTo("Very useful method<br>\n with new line"));
 
         comment = javadocReader.resolveMethodParameterComment(IntegrationType.class, "dummyMethod",
                 "kindaParameter");
@@ -48,7 +49,8 @@ public class JavadocReaderImplIntegrationTest {
         private String usefulField;
 
         /**
-         * Very useful method
+         * Very useful method<br>
+         * with new line
          *
          * @param kindaParameter mandatory param
          */

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/javadoc/JavadocUtilTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/javadoc/JavadocUtilTest.java
@@ -1,0 +1,24 @@
+package capital.scalable.restdocs.javadoc;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class JavadocUtilTest {
+
+    @Test
+    public void convertFromJavadoc() {
+        String actual = "First line is ok" +
+                "<br>  second line should be trimmed  " +
+                "<br/>\n\nthis is just \none\n\n line " +
+                "<p> first paragraph</p>" +
+                "<p> second paragraph \n \n  ";
+        String expected = "First line is ok" +
+                "|LB|second line should be trimmed" +
+                "|LB|this is just one line" +
+                "|LB||LB|first paragraph" +
+                "|LB||LB|second paragraph";
+        assertThat(JavadocUtil.convertFromJavadoc(actual, "|LB|"), is(expected));
+    }
+}

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/misc/DescriptionSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/misc/DescriptionSnippetTest.java
@@ -17,6 +17,7 @@
 package capital.scalable.restdocs.misc;
 
 
+import static capital.scalable.restdocs.OperationAttributeHelper.determineLineBreak;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -40,16 +41,22 @@ public class DescriptionSnippetTest extends AbstractSnippetTests {
                 "testDescription");
         JavadocReader javadocReader = mock(JavadocReader.class);
         when(javadocReader.resolveMethodComment(TestResource.class, "testDescription"))
-                .thenReturn("Sample method comment");
+                .thenReturn("Sample method comment<br>\n with newline\n <p>\n and one paragraph\n");
 
         setField(snippet, "expectedType", "description");
-        this.snippet.withContents(equalTo("Sample method comment"));
+        this.snippet.withContents(equalTo("Sample method comment" + lineBreak()
+                + "with newline" + lineBreak() + lineBreak()
+                + "and one paragraph"));
 
         new DescriptionSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
                 .attribute(JavadocReader.class.getName(), javadocReader)
                 .request("http://localhost/test")
                 .build());
+    }
+
+    private String lineBreak() {
+        return determineLineBreak(templateFormat);
     }
 
     private static class TestResource {

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/payload/JacksonRequestFieldSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/payload/JacksonRequestFieldSnippetTest.java
@@ -16,6 +16,7 @@
 
 package capital.scalable.restdocs.payload;
 
+import static capital.scalable.restdocs.OperationAttributeHelper.determineLineBreak;
 import static com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY;
 import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME;
 import static java.util.Collections.singletonList;
@@ -36,7 +37,6 @@ import org.hibernate.validator.constraints.NotBlank;
 import org.junit.Test;
 import org.springframework.restdocs.AbstractSnippetTests;
 import org.springframework.restdocs.templates.TemplateFormat;
-import org.springframework.restdocs.templates.TemplateFormats;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.method.HandlerMethod;
 
@@ -57,7 +57,7 @@ public class JacksonRequestFieldSnippetTest extends AbstractSnippetTests {
         when(javadocReader.resolveFieldComment(Item.class, "field1"))
                 .thenReturn("A string");
         when(javadocReader.resolveFieldComment(Item.class, "field2"))
-                .thenReturn("An integer");
+                .thenReturn("An integer<br>\n Very important\n <p>\n field");
 
         ConstraintReader constraintReader = mock(ConstraintReader.class);
         when(constraintReader.isMandatory(NotBlank.class)).thenReturn(true);
@@ -68,9 +68,11 @@ public class JacksonRequestFieldSnippetTest extends AbstractSnippetTests {
 
         this.snippet.expectRequestFields().withContents(
                 tableWithHeader("Path", "Type", "Optional", "Description")
-                        .row("field1", "String", "false", "A string")
-                        .row("field2", "Integer", "true",
-                                "An integer" + lineBreak() + "A constraint"));
+                        .row("field1", "String", "false", "A string.")
+                        .row("field2", "Integer", "true", "An integer" + lineBreak()
+                                + "Very important" + lineBreak() + lineBreak()
+                                + "field." + lineBreak()
+                                + "A constraint."));
 
         new JacksonRequestFieldSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
@@ -115,8 +117,8 @@ public class JacksonRequestFieldSnippetTest extends AbstractSnippetTests {
 
         this.snippet.expectRequestFields().withContents(
                 tableWithHeader("Path", "Type", "Optional", "Description")
-                        .row("[].field1", "String", "true", "A string")
-                        .row("[].field2", "Integer", "true", "An integer"));
+                        .row("[].field1", "String", "true", "A string.")
+                        .row("[].field2", "Integer", "true", "An integer."));
 
         new JacksonRequestFieldSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
@@ -150,10 +152,10 @@ public class JacksonRequestFieldSnippetTest extends AbstractSnippetTests {
 
         this.snippet.expectRequestFields().withContents(
                 tableWithHeader("Path", "Type", "Optional", "Description")
-                        .row("type", "String", "true", "A type")
-                        .row("commonField", "String", "true", "A common field")
-                        .row("subItem1Field", "Boolean", "true", "A sub item 1 field")
-                        .row("subItem2Field", "Integer", "true", "A sub item 2 field"));
+                        .row("type", "String", "true", "A type.")
+                        .row("commonField", "String", "true", "A common field.")
+                        .row("subItem1Field", "Boolean", "true", "A sub item 1 field.")
+                        .row("subItem2Field", "Integer", "true", "A sub item 2 field."));
 
         new JacksonRequestFieldSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
@@ -166,8 +168,7 @@ public class JacksonRequestFieldSnippetTest extends AbstractSnippetTests {
     }
 
     private String lineBreak() {
-        return templateFormat.getId().equals(TemplateFormats.asciidoctor().getId())
-                ? " +\n" : "<br>";
+        return determineLineBreak(templateFormat);
     }
 
     private static class TestResource {

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippetTest.java
@@ -71,9 +71,9 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
         this.snippet.expectResponseFields().withContents(
                 tableWithPrefix("\n",
                         tableWithHeader("Path", "Type", "Optional", "Description")
-                                .row("field1", "String", "false", "A string")
+                                .row("field1", "String", "false", "A string.")
                                 .row("field2", "Decimal", "true",
-                                        "A decimal" + lineBreak() + "A constraint")));
+                                        "A decimal." + lineBreak() + "A constraint.")));
 
         new JacksonResponseFieldSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
@@ -100,8 +100,8 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
         this.snippet.expectResponseFields().withContents(
                 tableWithPrefix("\n",
                         tableWithHeader("Path", "Type", "Optional", "Description")
-                                .row("[].field1", "String", "true", "A string")
-                                .row("[].field2", "Decimal", "true", "A decimal")));
+                                .row("[].field1", "String", "true", "A string.")
+                                .row("[].field2", "Decimal", "true", "A decimal.")));
 
         new JacksonResponseFieldSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
@@ -153,9 +153,9 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
         this.snippet.expectResponseFields().withContents(
                 tableWithPrefix(paginationPrefix(),
                         tableWithHeader("Path", "Type", "Optional", "Description")
-                                .row("field1", "String", "false", "A string")
+                                .row("field1", "String", "false", "A string.")
                                 .row("field2", "Decimal", "true",
-                                        "A decimal" + lineBreak() + "A constraint")));
+                                        "A decimal." + lineBreak() + "A constraint.")));
 
         new JacksonResponseFieldSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
@@ -189,9 +189,9 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
         this.snippet.expectResponseFields().withContents(
                 tableWithPrefix("\n",
                         tableWithHeader("Path", "Type", "Optional", "Description")
-                                .row("field1", "String", "false", "A string")
+                                .row("field1", "String", "false", "A string.")
                                 .row("field2", "Decimal", "true",
-                                        "A decimal" + lineBreak() + "A constraint")));
+                                        "A decimal." + lineBreak() + "A constraint.")));
 
         new JacksonResponseFieldSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/PathParametersSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/PathParametersSnippetTest.java
@@ -54,8 +54,8 @@ public class PathParametersSnippetTest extends AbstractSnippetTests {
 
         this.snippet.expectPathParameters().withContents(
                 tableWithHeader("Parameter", "Type", "Optional", "Description")
-                        .row("id", "Integer", "false", "An integer")
-                        .row("subid", "String", "false", "A string"));
+                        .row("id", "Integer", "false", "An integer.")
+                        .row("subid", "String", "false", "A string."));
 
         new PathParametersSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/RequestParametersSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/RequestParametersSnippetTest.java
@@ -56,8 +56,8 @@ public class RequestParametersSnippetTest extends AbstractSnippetTests {
 
         this.snippet.expectRequestParameters().withContents(
                 tableWithHeader("Parameter", "Type", "Optional", "Description")
-                        .row("type", "Integer", "false", "An integer")
-                        .row("text", "String", "true", "A string"));
+                        .row("type", "Integer", "false", "An integer.")
+                        .row("text", "String", "true", "A string."));
 
         new RequestParametersSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)

--- a/spring-auto-restdocs-example/generated-docs/index.html
+++ b/spring-auto-restdocs-example/generated-docs/index.html
@@ -630,7 +630,7 @@ switch directions, e.g. <code>?sort=firstname&amp;sort=lastname,asc</code>.</p><
             <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
             <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
             <td class="tableblock halign-left valign-top"><p class="tableblock">ID of the item.<br>
-                Must be a valid ID</p></td>
+                Must be a valid ID.</p></td>
         </tr>
         </tbody>
     </table>
@@ -673,13 +673,13 @@ because the template returns "No data." instead of an empty table.</p>
 <td class="tableblock halign-left valign-top"><p class="tableblock">custom1</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 1</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 1.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">custom2</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 2</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 2.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes</p></td>
@@ -692,15 +692,15 @@ because the template returns "No data." instead of an empty table.</p>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.<br>
-Size must be between 2 and 20 inclusive</p></td>
+    Size must be between 2 and 20 inclusive.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.number</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.<br>
-Must be at least 1<br>
-Must be at most 10</p></td>
+    Must be at least 1.<br>
+    Must be at most 10.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.bool</p></td>
@@ -713,8 +713,8 @@ Must be at most 10</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.<br>
-Must be at least 1<br>
-Must be at most 10</p></td>
+    Must be at least 1.<br>
+    Must be at most 10.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.amount</p></td>
@@ -727,7 +727,7 @@ Must be at most 10</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.<br>
-Must be one of [ONE, TWO]</p></td>
+    Must be one of [ONE, TWO].</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">children</p></td>
@@ -838,13 +838,13 @@ Content-Length: 378
 <td class="tableblock halign-left valign-top"><p class="tableblock">[].custom1</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 1</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 1.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">[].custom2</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 2</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 2.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes</p></td>
@@ -857,15 +857,15 @@ Content-Length: 378
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.<br>
-Size must be between 2 and 20 inclusive</p></td>
+    Size must be between 2 and 20 inclusive.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.number</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.<br>
-Must be at least 1<br>
-Must be at most 10</p></td>
+    Must be at least 1.<br>
+    Must be at most 10.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.bool</p></td>
@@ -878,8 +878,8 @@ Must be at most 10</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.<br>
-Must be at least 1<br>
-Must be at most 10</p></td>
+    Must be at least 1.<br>
+    Must be at most 10.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.amount</p></td>
@@ -892,7 +892,7 @@ Must be at most 10</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.<br>
-Must be one of [ONE, TWO]</p></td>
+    Must be one of [ONE, TWO].</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">[].children</p></td>
@@ -1010,18 +1010,18 @@ Content-Length: 483
 <td class="tableblock halign-left valign-top"><p class="tableblock">true<br>
 EN: false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.<br>
-DE: Size must be between 2 and 10 inclusive<br>
-EN: Size must be between 4 and 12 inclusive<br>
-Length must be between 0 and 20 inclusive</p></td>
+    DE: Size must be between 2 and 10 inclusive.<br>
+    EN: Size must be between 4 and 12 inclusive.<br>
+    Length must be between 0 and 20 inclusive.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Country dependent type of the item.<br>
-DE: Must be one of [klein, groß]<br>
-EN: Must be one of [small, big]<br>
-Size must be between 0 and 1000 inclusive</p></td>
+    DE: Must be one of [klein, groß].<br>
+    EN: Must be one of [small, big].<br>
+    Size must be between 0 and 1000 inclusive.</p></td>
 </tr>
 </tbody>
 </table>
@@ -1036,7 +1036,7 @@ Size must be between 0 and 1000 inclusive</p></td>
     <h4 id="_example_request"><a class="anchor" href="#_example_request"></a>2.3.6. Example request</h4>
 <div class="listingblock">
 <div class="content">
-    <pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items' -i -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer 4854a708-abad-453a-bc3a-a77d088dfa1f' -d '{"description":"Hot News"}'</code></pre>
+    <pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items' -i -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer 5637b963-e2e4-4578-8158-3faa5b2d0912' -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
 </div>
@@ -1093,7 +1093,7 @@ Location: /items/2</code></pre>
             <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
             <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
             <td class="tableblock halign-left valign-top"><p class="tableblock">Item ID.<br>
-                Must be a valid ID</p></td>
+                Must be a valid ID.</p></td>
         </tr>
         </tbody>
     </table>
@@ -1128,18 +1128,18 @@ Location: /items/2</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true<br>
 EN: false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.<br>
-DE: Size must be between 2 and 10 inclusive<br>
-EN: Size must be between 4 and 12 inclusive<br>
-Length must be between 0 and 20 inclusive</p></td>
+    DE: Size must be between 2 and 10 inclusive.<br>
+    EN: Size must be between 4 and 12 inclusive.<br>
+    Length must be between 0 and 20 inclusive.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Country dependent type of the item.<br>
-DE: Must be one of [klein, groß]<br>
-EN: Must be one of [small, big]<br>
-Size must be between 0 and 1000 inclusive</p></td>
+    DE: Must be one of [klein, groß].<br>
+    EN: Must be one of [small, big].<br>
+    Size must be between 0 and 1000 inclusive.</p></td>
 </tr>
 </tbody>
 </table>
@@ -1172,13 +1172,13 @@ Size must be between 0 and 1000 inclusive</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">custom1</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 1</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 1.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">custom2</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 2</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 2.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes</p></td>
@@ -1191,15 +1191,15 @@ Size must be between 0 and 1000 inclusive</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.<br>
-Size must be between 2 and 20 inclusive</p></td>
+    Size must be between 2 and 20 inclusive.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.number</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.<br>
-Must be at least 1<br>
-Must be at most 10</p></td>
+    Must be at least 1.<br>
+    Must be at most 10.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.bool</p></td>
@@ -1212,8 +1212,8 @@ Must be at most 10</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.<br>
-Must be at least 1<br>
-Must be at most 10</p></td>
+    Must be at least 1.<br>
+    Must be at most 10.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.amount</p></td>
@@ -1226,7 +1226,7 @@ Must be at most 10</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.<br>
-Must be one of [ONE, TWO]</p></td>
+    Must be one of [ONE, TWO].</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">children</p></td>
@@ -1247,7 +1247,7 @@ Must be one of [ONE, TWO]</p></td>
     <h4 id="_example_request_2"><a class="anchor" href="#_example_request_2"></a>2.4.6. Example request</h4>
 <div class="listingblock">
 <div class="content">
-    <pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X PUT -H 'Content-Type: application/json' -H 'Authorization: Bearer 4854a708-abad-453a-bc3a-a77d088dfa1f' -d '{"description":"Hot News"}'</code></pre>
+    <pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X PUT -H 'Content-Type: application/json' -H 'Authorization: Bearer 5637b963-e2e4-4578-8158-3faa5b2d0912' -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
 </div>
@@ -1280,6 +1280,12 @@ Content-Length: 90
 <div class="paragraph">
 <p><code>DELETE /items/{id}</code></p>
 </div>
+    <div class="paragraph">
+        <p>Deletes item.<br>
+            Item must exist.<br>
+            <br>
+            Non existing items are ignored</p>
+    </div>
 <div class="sect3">
 <h4 id="_authorization_5"><a class="anchor" href="#_authorization_5"></a>2.5.1. Authorization</h4>
 <div class="paragraph">
@@ -1308,7 +1314,7 @@ Content-Length: 90
             <td class="tableblock halign-left valign-top"><p class="tableblock">id</p></td>
             <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
             <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-            <td class="tableblock halign-left valign-top"><p class="tableblock">Must be a valid ID</p></td>
+            <td class="tableblock halign-left valign-top"><p class="tableblock">Must be a valid ID.</p></td>
         </tr>
         </tbody>
     </table>
@@ -1336,7 +1342,7 @@ Content-Length: 90
 <div class="listingblock">
 <div class="content">
     <pre class="highlightjs highlight"><code class="language-bash"
-                                             data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X DELETE -H 'Authorization: Bearer 4854a708-abad-453a-bc3a-a77d088dfa1f'</code></pre>
+                                             data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X DELETE -H 'Authorization: Bearer 5637b963-e2e4-4578-8158-3faa5b2d0912'</code></pre>
 </div>
 </div>
 </div>
@@ -1392,15 +1398,15 @@ X-Frame-Options: DENY</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
     <td class="tableblock halign-left valign-top"><p class="tableblock">Item ID.<br>
-        Must be a valid ID</p></td>
+        Must be a valid ID.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">child</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
     <td class="tableblock halign-left valign-top"><p class="tableblock">Child ID.<br>
-        DE: Must be at most 2<br>
-        EN: Must be at least 1</p></td>
+        DE: Must be at most 2.<br>
+        EN: Must be at least 1.</p></td>
 </tr>
 </tbody>
 </table>
@@ -1445,13 +1451,13 @@ X-Frame-Options: DENY</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock">custom1</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 1</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 1.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">custom2</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 2</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 2.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes</p></td>
@@ -1464,15 +1470,15 @@ X-Frame-Options: DENY</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.<br>
-Size must be between 2 and 20 inclusive</p></td>
+    Size must be between 2 and 20 inclusive.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.number</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.<br>
-Must be at least 1<br>
-Must be at most 10</p></td>
+    Must be at least 1.<br>
+    Must be at most 10.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.bool</p></td>
@@ -1485,8 +1491,8 @@ Must be at most 10</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.<br>
-Must be at least 1<br>
-Must be at most 10</p></td>
+    Must be at least 1.<br>
+    Must be at most 10.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.amount</p></td>
@@ -1499,7 +1505,7 @@ Must be at most 10</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.<br>
-Must be one of [ONE, TWO]</p></td>
+    Must be one of [ONE, TWO].</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">children</p></td>
@@ -1591,15 +1597,15 @@ Content-Length: 99
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
     <td class="tableblock halign-left valign-top"><p class="tableblock">Lookup on description field.<br>
-        Size must be between 0 and 255 inclusive</p></td>
+        Size must be between 0 and 255 inclusive.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">hint</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
     <td class="tableblock halign-left valign-top"><p class="tableblock">Lookup hint.<br>
-        Must be at least 10<br>
-        Must be at most 100</p></td>
+        Must be at least 10.<br>
+        Must be at most 100.</p></td>
 </tr>
 </tbody>
 </table>
@@ -1641,13 +1647,13 @@ Content-Length: 99
 <td class="tableblock halign-left valign-top"><p class="tableblock">custom1</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 1</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 1.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">custom2</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 2</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Custom meta attribute 2.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes</p></td>
@@ -1660,15 +1666,15 @@ Content-Length: 99
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.<br>
-Size must be between 2 and 20 inclusive</p></td>
+    Size must be between 2 and 20 inclusive.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.number</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.<br>
-Must be at least 1<br>
-Must be at most 10</p></td>
+    Must be at least 1.<br>
+    Must be at most 10.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.bool</p></td>
@@ -1681,8 +1687,8 @@ Must be at most 10</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.<br>
-Must be at least 1<br>
-Must be at most 10</p></td>
+    Must be at least 1.<br>
+    Must be at most 10.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.amount</p></td>
@@ -1695,7 +1701,7 @@ Must be at most 10</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.<br>
-Must be one of [ONE, TWO]</p></td>
+    Must be one of [ONE, TWO].</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">children</p></td>
@@ -1757,14 +1763,14 @@ Content-Length: 625
   } ],
   "pageable" : null,
   "total" : 1,
-  "totalPages" : 1,
   "last" : true,
+  "totalPages" : 1,
   "totalElements" : 1,
   "size" : 0,
   "number" : 0,
-  "sort" : null,
   "first" : true,
-  "numberOfElements" : 1
+  "numberOfElements" : 1,
+  "sort" : null
 }</code></pre>
 </div>
 </div>

--- a/spring-auto-restdocs-example/generated-docs/index.html
+++ b/spring-auto-restdocs-example/generated-docs/index.html
@@ -1036,7 +1036,7 @@ EN: false</p></td>
     <h4 id="_example_request"><a class="anchor" href="#_example_request"></a>2.3.6. Example request</h4>
 <div class="listingblock">
 <div class="content">
-    <pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items' -i -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer 5637b963-e2e4-4578-8158-3faa5b2d0912' -d '{"description":"Hot News"}'</code></pre>
+    <pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items' -i -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer 670b9a4e-bd05-4fe1-9514-1fbff5c61f68' -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
 </div>
@@ -1247,7 +1247,7 @@ EN: false</p></td>
     <h4 id="_example_request_2"><a class="anchor" href="#_example_request_2"></a>2.4.6. Example request</h4>
 <div class="listingblock">
 <div class="content">
-    <pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X PUT -H 'Content-Type: application/json' -H 'Authorization: Bearer 5637b963-e2e4-4578-8158-3faa5b2d0912' -d '{"description":"Hot News"}'</code></pre>
+    <pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X PUT -H 'Content-Type: application/json' -H 'Authorization: Bearer 670b9a4e-bd05-4fe1-9514-1fbff5c61f68' -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
 </div>
@@ -1342,7 +1342,7 @@ Content-Length: 90
 <div class="listingblock">
 <div class="content">
     <pre class="highlightjs highlight"><code class="language-bash"
-                                             data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X DELETE -H 'Authorization: Bearer 5637b963-e2e4-4578-8158-3faa5b2d0912'</code></pre>
+                                             data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X DELETE -H 'Authorization: Bearer 670b9a4e-bd05-4fe1-9514-1fbff5c61f68'</code></pre>
 </div>
 </div>
 </div>
@@ -1768,9 +1768,9 @@ Content-Length: 625
   "totalElements" : 1,
   "size" : 0,
   "number" : 0,
-  "first" : true,
+  "sort" : null,
   "numberOfElements" : 1,
-  "sort" : null
+  "first" : true
 }</code></pre>
 </div>
 </div>

--- a/spring-auto-restdocs-example/src/main/java/capital/scalable/restdocs/example/items/ItemResource.java
+++ b/spring-auto-restdocs-example/src/main/java/capital/scalable/restdocs/example/items/ItemResource.java
@@ -119,6 +119,15 @@ public class ItemResource {
         return new ItemResponse(id, itemUpdate.getDescription(), null, null, null);
     }
 
+    /**
+     * Deletes item.
+     * <br>
+     * Item must exist.
+     * <p>
+     * Non existing items are ignored
+     *
+     * @param id
+     */
     @RequestMapping(value = "{id}", method = DELETE)
     public void deleteItem(@PathVariable("id") @Id String id) {
         // Item with the given ID is deleted.


### PR DESCRIPTION
this is a quick fix for multiline Javadocs. However we might want to do proper conversion from Javadoc tags to asciidoc/markdown.