### PR TITLE
Support for multiple Javadoc directories

### DIFF
--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/JacksonResultHandlers.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/JacksonResultHandlers.java
@@ -48,7 +48,7 @@ public abstract class JacksonResultHandlers {
             setHandlerMethod(result.getRequest(), (HandlerMethod) result.getHandler());
             setObjectMapper(result.getRequest(), objectMapper);
             initRequestPattern(result.getRequest());
-            setJavadocReader(result.getRequest(), new JavadocReaderImpl());
+            setJavadocReader(result.getRequest(), JavadocReaderImpl.createWithSystemProperty());
             setConstraintReader(result.getRequest(), new ConstraintReaderImpl());
         }
     }

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/javadoc/JavadocReaderImpl.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/javadoc/JavadocReaderImpl.java
@@ -16,8 +16,9 @@
 
 package capital.scalable.restdocs.javadoc;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.commons.lang3.StringUtils.split;
 import static org.slf4j.LoggerFactory.getLogger;
-import static org.springframework.util.StringUtils.split;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -33,7 +34,7 @@ import org.slf4j.Logger;
 
 public class JavadocReaderImpl implements JavadocReader {
     private static final Logger log = getLogger(JavadocReader.class);
-    private static final String PATH_DELIMITER = ";";
+    private static final String PATH_DELIMITER = ",";
     private static final String JAVADOC_JSON_DIR_PROPERTY =
             "org.springframework.restdocs.javadocJsonDir";
 
@@ -140,13 +141,13 @@ public class JavadocReaderImpl implements JavadocReader {
 
     private static List<File> toAbsoluteDirs(String javadocJsonDirs) {
         List<File> absoluteDirs = new ArrayList<>();
-        String[] dirs = split(javadocJsonDirs, PATH_DELIMITER);
-        if (dirs != null) {
-            for (String d : dirs) {
-                absoluteDirs.add(new File(d).getAbsoluteFile());
+        if (isNotBlank(javadocJsonDirs)) {
+            String[] dirs = split(javadocJsonDirs, PATH_DELIMITER);
+            for (String dir : dirs) {
+                if (isNotBlank(dir)) {
+                    absoluteDirs.add(new File(dir.trim()).getAbsoluteFile());
+                }
             }
-        } else {
-            absoluteDirs.add(new File(javadocJsonDirs).getAbsoluteFile());
         }
         return absoluteDirs;
     }

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/javadoc/JavadocReaderImpl.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/javadoc/JavadocReaderImpl.java
@@ -17,11 +17,13 @@
 package capital.scalable.restdocs.javadoc;
 
 import static org.slf4j.LoggerFactory.getLogger;
-import static org.springframework.util.StringUtils.hasText;
+import static org.springframework.util.StringUtils.split;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -31,86 +33,121 @@ import org.slf4j.Logger;
 
 public class JavadocReaderImpl implements JavadocReader {
     private static final Logger log = getLogger(JavadocReader.class);
+    private static final String PATH_DELIMITER = ";";
+    private static final String JAVADOC_JSON_DIR_PROPERTY =
+            "org.springframework.restdocs.javadocJsonDir";
 
     private final Map<String, ClassJavadoc> classCache = new ConcurrentHashMap<>();
-    private final ObjectMapper mapper = new ObjectMapper();
-    private final File javadocJsonDir;
+    private final ObjectMapper mapper;
+    private final List<File> absoluteBaseDirs;
 
-    public JavadocReaderImpl() {
-        this(null);
+    private JavadocReaderImpl(ObjectMapper mapper, List<File> absoluteBaseDirs) {
+        this.mapper = mapper;
+        this.absoluteBaseDirs = absoluteBaseDirs;
     }
 
-    public JavadocReaderImpl(String javadocJsonDir) {
-        if (javadocJsonDir != null) {
-            this.javadocJsonDir = new File(javadocJsonDir).getAbsoluteFile();
-        } else {
-            this.javadocJsonDir = systemPropertyJavadocJsonDir();
-        }
-
-        mapper.setVisibility(mapper.getSerializationConfig().getDefaultVisibilityChecker()
-                .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
-                .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
-                .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
-                .withCreatorVisibility(JsonAutoDetect.Visibility.NONE));
+    public static JavadocReaderImpl createWithSystemProperty() {
+        String systemProperty = System.getProperties().getProperty(JAVADOC_JSON_DIR_PROPERTY);
+        return new JavadocReaderImpl(objectMapper(), toAbsoluteDirs(systemProperty));
     }
 
-    private ClassJavadoc getClass(Class<?> clazz) {
-        String packageName = clazz.getPackage().getName();
-        String packageDir = packageName.replace(".", File.separator);
-        String className = clazz.getCanonicalName().replaceAll(packageName + "\\.?", "");
-        String fileName = packageDir + "/" + className + ".json";
-
-        ClassJavadoc classJavadoc = classCache.get(fileName);
-        if (classJavadoc != null) {
-            return classJavadoc;
-        }
-
-        try {
-            File docSource = makeRelativeToConfiguredJavadocJsonDir(new File(fileName));
-            classJavadoc = mapper
-                    .readerFor(ClassJavadoc.class)
-                    .readValue(docSource);
-        } catch (FileNotFoundException e) {
-            log.warn("No Javadoc found for {} at {}", clazz.getCanonicalName(), fileName);
-            classJavadoc = new ClassJavadoc();
-        } catch (IOException e) {
-            log.error("Problem reading file {}", fileName, e);
-            classJavadoc = new ClassJavadoc();
-        }
-
-        classCache.put(fileName, classJavadoc);
-        return classJavadoc;
+    /**
+     * Used for testing.
+     */
+    static JavadocReaderImpl createWith(String javadocJsonDir) {
+        return new JavadocReaderImpl(objectMapper(), toAbsoluteDirs(javadocJsonDir));
     }
 
     @Override
     public String resolveFieldComment(Class<?> javaBaseClass, String javaFieldName) {
-        return getClass(javaBaseClass).getFieldComment(javaFieldName);
+        return classJavadoc(javaBaseClass).getFieldComment(javaFieldName);
     }
 
     @Override
     public String resolveMethodComment(Class<?> javaBaseClass, String javaMethodName) {
-        return getClass(javaBaseClass).getMethodComment(javaMethodName);
+        return classJavadoc(javaBaseClass).getMethodComment(javaMethodName);
     }
 
     @Override
     public String resolveMethodParameterComment(Class<?> javaBaseClass, String javaMethodName,
             String javaParameterName) {
-        return getClass(javaBaseClass).getMethodParameterComment(javaMethodName, javaParameterName);
+        return classJavadoc(javaBaseClass)
+                .getMethodParameterComment(javaMethodName, javaParameterName);
     }
 
-    private File makeRelativeToConfiguredJavadocJsonDir(File outputFile) {
-        if (javadocJsonDir != null) {
-            return new File(javadocJsonDir, outputFile.getPath());
+    private ClassJavadoc classJavadoc(Class<?> clazz) {
+        String relativePath = classToRelativePath(clazz);
+        ClassJavadoc classJavadocFromCache = classCache.get(relativePath);
+        if (classJavadocFromCache != null) {
+            return classJavadocFromCache;
+        } else {
+            ClassJavadoc classJavadoc = readFiles(clazz, relativePath);
+            classCache.put(relativePath, classJavadoc);
+            return classJavadoc;
         }
-        return new File(outputFile.getPath());
     }
 
-    private File systemPropertyJavadocJsonDir() {
-        String outputDir = System.getProperties().getProperty(
-                "org.springframework.restdocs.javadocJsonDir");
-        if (hasText(outputDir)) {
-            return new File(outputDir).getAbsoluteFile();
+    private String classToRelativePath(Class<?> clazz) {
+        String packageName = clazz.getPackage().getName();
+        String packageDir = packageName.replace(".", File.separator);
+        String className = clazz.getCanonicalName().replaceAll(packageName + "\\.?", "");
+        return new File(packageDir, className + ".json").getPath();
+    }
+
+    private ClassJavadoc readFiles(Class<?> clazz, String relativePath) {
+        if (absoluteBaseDirs.isEmpty()) {
+            // No absolute directory is configured and thus we try to find the file relative.
+            ClassJavadoc classJavadoc = readFile(new File(relativePath));
+            if (classJavadoc != null) {
+                return classJavadoc;
+            }
+        } else {
+            // Try to find the file in all configured directories.
+            for (File dir : absoluteBaseDirs) {
+                ClassJavadoc classJavadoc = readFile(new File(dir, relativePath));
+                if (classJavadoc != null) {
+                    return classJavadoc;
+                }
+            }
+        }
+        log.warn("No Javadoc found for class {}", clazz.getCanonicalName());
+        return new ClassJavadoc();
+    }
+
+    private ClassJavadoc readFile(File docSource) {
+        try {
+            return mapper
+                    .readerFor(ClassJavadoc.class)
+                    .readValue(docSource);
+        } catch (FileNotFoundException e) {
+            // Ignored as we might try more than one file and we warn if no Javadoc file
+            // is found at the end.
+        } catch (IOException e) {
+            log.error("Failed to read file {}", docSource.getName(), e);
         }
         return null;
+    }
+
+    private static ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.setVisibility(mapper.getSerializationConfig().getDefaultVisibilityChecker()
+                .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
+                .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withCreatorVisibility(JsonAutoDetect.Visibility.NONE));
+        return mapper;
+    }
+
+    private static List<File> toAbsoluteDirs(String javadocJsonDirs) {
+        List<File> absoluteDirs = new ArrayList<>();
+        String[] dirs = split(javadocJsonDirs, PATH_DELIMITER);
+        if (dirs != null) {
+            for (String d : dirs) {
+                absoluteDirs.add(new File(d).getAbsoluteFile());
+            }
+        } else {
+            absoluteDirs.add(new File(javadocJsonDirs).getAbsoluteFile());
+        }
+        return absoluteDirs;
     }
 }

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/javadoc/JavadocReaderImplIntegrationTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/javadoc/JavadocReaderImplIntegrationTest.java
@@ -25,7 +25,8 @@ public class JavadocReaderImplIntegrationTest {
 
     @Test
     public void resolveComments() {
-        JavadocReader javadocReader = new JavadocReaderImpl(); // using dir from pom.xml
+        JavadocReader javadocReader =
+                JavadocReaderImpl.createWithSystemProperty(); // using dir from pom.xml
         String comment = javadocReader.resolveFieldComment(IntegrationType.class, "usefulField");
         assertThat(comment, equalTo("Very useful field"));
 

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/javadoc/JavadocReaderImplTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/javadoc/JavadocReaderImplTest.java
@@ -20,6 +20,9 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.io.File;
+import java.nio.file.Path;
+
 import org.junit.Test;
 
 public class JavadocReaderImplTest {
@@ -29,21 +32,30 @@ public class JavadocReaderImplTest {
 
     @Test
     public void resolveFieldComment() {
-        JavadocReader javadocReader = new JavadocReaderImpl(SOURCE_DIR);
+        JavadocReader javadocReader = JavadocReaderImpl.createWith(SOURCE_DIR);
+        String comment = javadocReader.resolveFieldComment(SimpleType.class, "simpleField");
+        assertThat(comment, equalTo("Simple field comment"));
+    }
+
+    @Test
+    public void resolveFieldCommentAcrossDirectories() {
+        String nonExistentDir = new File(SOURCE_DIR, "does-not-exist").getPath();
+        String javadocDirs = nonExistentDir + ";" + SOURCE_DIR;
+        JavadocReader javadocReader = JavadocReaderImpl.createWith(javadocDirs);
         String comment = javadocReader.resolveFieldComment(SimpleType.class, "simpleField");
         assertThat(comment, equalTo("Simple field comment"));
     }
 
     @Test
     public void resolveMethodComment() {
-        JavadocReader javadocReader = new JavadocReaderImpl(SOURCE_DIR);
+        JavadocReader javadocReader = JavadocReaderImpl.createWith(SOURCE_DIR);
         String comment = javadocReader.resolveMethodComment(SimpleType.class, "simpleMethod");
         assertThat(comment, equalTo("Simple method comment"));
     }
 
     @Test
     public void resolveMethodParameterComment() {
-        JavadocReader javadocReader = new JavadocReaderImpl(SOURCE_DIR);
+        JavadocReader javadocReader = JavadocReaderImpl.createWith(SOURCE_DIR);
         String comment = javadocReader.resolveMethodParameterComment(SimpleType.class,
                 "simpleMethod", "simpleParameter");
         assertThat(comment, equalTo("Simple parameter comment"));
@@ -51,7 +63,7 @@ public class JavadocReaderImplTest {
 
     @Test
     public void jsonFileDoesNotExist() {
-        JavadocReader javadocReader = new JavadocReaderImpl(SOURCE_DIR);
+        JavadocReader javadocReader = JavadocReaderImpl.createWith(SOURCE_DIR);
 
         // json file for class does not exist
         String comment = javadocReader.resolveFieldComment(NotExisting.class, "simpleField2");
@@ -65,7 +77,7 @@ public class JavadocReaderImplTest {
 
     @Test
     public void jsonNotDocumented() {
-        JavadocReader javadocReader = new JavadocReaderImpl(SOURCE_DIR);
+        JavadocReader javadocReader = JavadocReaderImpl.createWith(SOURCE_DIR);
 
         // json file exists but field/method/parameter is not present
         String comment = javadocReader.resolveFieldComment(SimpleType.class, "simpleField2");

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/javadoc/JavadocReaderImplTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/javadoc/JavadocReaderImplTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 import java.io.File;
-import java.nio.file.Path;
 
 import org.junit.Test;
 
@@ -40,10 +39,18 @@ public class JavadocReaderImplTest {
     @Test
     public void resolveFieldCommentAcrossDirectories() {
         String nonExistentDir = new File(SOURCE_DIR, "does-not-exist").getPath();
-        String javadocDirs = nonExistentDir + ";" + SOURCE_DIR;
+        String javadocDirs = " ," + nonExistentDir + " , " + SOURCE_DIR;
         JavadocReader javadocReader = JavadocReaderImpl.createWith(javadocDirs);
         String comment = javadocReader.resolveFieldComment(SimpleType.class, "simpleField");
         assertThat(comment, equalTo("Simple field comment"));
+    }
+
+    @Test
+    public void resolveShouldNotFailOnNullDir() {
+        String javadocDirs = null;
+        JavadocReader javadocReader = JavadocReaderImpl.createWith(javadocDirs);
+        String comment = javadocReader.resolveFieldComment(SimpleType.class, "simpleField");
+        assertThat(comment, equalTo(""));
     }
 
     @Test

--- a/spring-auto-restdocs-docs/getting-started.adoc
+++ b/spring-auto-restdocs-docs/getting-started.adoc
@@ -74,7 +74,7 @@ Spring Auto REST Docs has the following minimum requirements:
 </build>
 ----
 <1> Has to be removed if `@RestdocsNotExpanded` is used.
-<2> Multiple directories can be listed by separating them with `;`.
+<2> Multiple directories can be listed by separating them with `,`.
 The directories are processed in order and only the first found JSON file is used.
 +
 [source,groovy,indent=0,subs="verbatim,attributes",role="secondary"]
@@ -113,7 +113,7 @@ jar {
     dependsOn asciidoctor
 }
 ----
-<1> Multiple directories can be listed by separating them with `;`.
+<1> Multiple directories can be listed by separating them with `,`.
 The directories are processed in order and only the first found JSON file is used.
 <2> Has to be `compile` instead of `testCompile` if `@RestdocsNotExpanded` is used.
 

--- a/spring-auto-restdocs-docs/getting-started.adoc
+++ b/spring-auto-restdocs-docs/getting-started.adoc
@@ -40,7 +40,7 @@ Spring Auto REST Docs has the following minimum requirements:
                         \${snippetsDirectory}
                     </org.springframework.restdocs.outputDir>
                     <org.springframework.restdocs.javadocJsonDir>
-                        \${project.build.directory}/generated-javadoc-json
+                        \${project.build.directory}/generated-javadoc-json <2>
                     </org.springframework.restdocs.javadocJsonDir>
                 </systemPropertyVariables>
              </configuration>
@@ -74,6 +74,8 @@ Spring Auto REST Docs has the following minimum requirements:
 </build>
 ----
 <1> Has to be removed if `@RestdocsNotExpanded` is used.
+<2> Multiple directories can be listed by separating them with `;`.
+The directories are processed in order and only the first found JSON file is used.
 +
 [source,groovy,indent=0,subs="verbatim,attributes",role="secondary"]
 .Gradle
@@ -83,11 +85,11 @@ configurations {
 }
 
 ext {
-    javadocJsonDir = file("$buildDir/generated-javadoc-json")
+    javadocJsonDir = file("$buildDir/generated-javadoc-json") <1>
 }
 
 dependencies {
-    testCompile group: 'capital.scalable', name: 'spring-auto-restdocs-core', version: '1.0.5' <1>
+    testCompile group: 'capital.scalable', name: 'spring-auto-restdocs-core', version: '1.0.5' <2>
     jsondoclet group: 'capital.scalable', name: 'spring-auto-restdocs-json-doclet', version: '1.0.5'
 }
 
@@ -111,7 +113,9 @@ jar {
     dependsOn asciidoctor
 }
 ----
-<1> Has to be `compile` instead of `testCompile` if `@RestdocsNotExpanded` is used.
+<1> Multiple directories can be listed by separating them with `;`.
+The directories are processed in order and only the first found JSON file is used.
+<2> Has to be `compile` instead of `testCompile` if `@RestdocsNotExpanded` is used.
 
 . Configure MockMvc
 +
@@ -167,4 +171,3 @@ public void setUp() throws Exception {
 https://github.com/ScaCap/spring-auto-restdocs/tree/master/spring-auto-restdocs-example[This project] includes a sample application that demonstrates most features:
 
 The generated documentation of the example project can be viewed https://htmlpreview.github.io/?https://github.com/ScaCap/spring-auto-restdocs/blob/master/spring-auto-restdocs-example/generated-docs/index.html[here].
-

--- a/spring-auto-restdocs-docs/index.adoc
+++ b/spring-auto-restdocs-docs/index.adoc
@@ -44,9 +44,13 @@ Does it work with REST Assured tests?::
   Not yet. We may add support for REST Assured in the future, but your PR is also welcome.
 Is Jackson required for automatic field documentation?::
   Yes, this project only includes a Jackson visitor so far.
-Can multiple directories be configured with `javadocJsonDir`?::
-  Yes, multiple directories can be listed by separating them with `;`.
-  The directories are processed in order and only the first found JSON file is used.
+Is a multi-module project setup supported?::
+  The JSON doclet and the REST Docs snippets produce files.
+  Therefore, all results can be copied across modules or projects.
+  Instead of copying, multiple source directories for
+  the JSON files can be configured with the `javadocJsonDir` property.
+  Directories are separated by `,` and are processed in order
+  and only the first found JSON file is used.
 
 include::getting-started.adoc[]
 include::snippets.adoc[]

--- a/spring-auto-restdocs-docs/index.adoc
+++ b/spring-auto-restdocs-docs/index.adoc
@@ -44,6 +44,9 @@ Does it work with REST Assured tests?::
   Not yet. We may add support for REST Assured in the future, but your PR is also welcome.
 Is Jackson required for automatic field documentation?::
   Yes, this project only includes a Jackson visitor so far.
+Can multiple directories be configured with `javadocJsonDir`?::
+  Yes, multiple directories can be listed by separating them with `;`.
+  The directories are processed in order and only the first found JSON file is used.
 
 include::getting-started.adoc[]
 include::snippets.adoc[]


### PR DESCRIPTION
Changes:
* Support multiple Javadoc JSON directories by supporting directories separated by `,`, e.g. `dir1,dir2,dir3`.
* Fix hard-coded use of `/`.
* Refactored `JavadocReaderImpl` for better readability.

Closes #58