### PR TITLE
Version 1.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>capital.scalable</groupId>
     <artifactId>spring-auto-restdocs-parent</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>1.0.7</version>
     <packaging>pom</packaging>
 
     <name>Spring Auto REST Docs Parent POM</name>

--- a/spring-auto-restdocs-core/pom.xml
+++ b/spring-auto-restdocs-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>capital.scalable</groupId>
         <artifactId>spring-auto-restdocs-parent</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.0.7</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/spring-auto-restdocs-docs/pom.xml
+++ b/spring-auto-restdocs-docs/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>capital.scalable</groupId>
         <artifactId>spring-auto-restdocs-parent</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.0.7</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/spring-auto-restdocs-example/build.gradle
+++ b/spring-auto-restdocs-example/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'org.springframework.boot'
 apply plugin: 'org.asciidoctor.convert'
 
 group = 'capital.scalable'
-version = '1.0.7-SNAPSHOT'
+version = '1.0.7'
 
 description = """Spring Auto REST Docs Example Project"""
 

--- a/spring-auto-restdocs-example/pom.xml
+++ b/spring-auto-restdocs-example/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>capital.scalable</groupId>
     <artifactId>spring-auto-restdocs-example</artifactId>
-    <version>1.0.7-SNAPSHOT</version> <!-- not related to spring-auto-restdocs version -->
+    <version>1.0.7</version> <!-- not related to spring-auto-restdocs version -->
 
     <name>Spring Auto REST Docs Example Project</name>
     <description>Example project for Spring Auto REST Docs</description>
@@ -24,7 +24,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <snippetsDirectory>${project.build.directory}/generated-snippets</snippetsDirectory>
         <start-class>capital.scalable.restdocs.example.Application</start-class>
-        <spring-auto-restdocs.version>1.0.7-SNAPSHOT</spring-auto-restdocs.version>
+        <spring-auto-restdocs.version>1.0.7</spring-auto-restdocs.version>
     </properties>
 
     <dependencies>

--- a/spring-auto-restdocs-json-doclet/pom.xml
+++ b/spring-auto-restdocs-json-doclet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>capital.scalable</groupId>
         <artifactId>spring-auto-restdocs-parent</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.0.7</version>
         <relativePath>..</relativePath>
     </parent>
 


### PR DESCRIPTION
Only one real change since version 1.0.6:
* Update to Spring REST Docs v1.1.3 (https://github.com/ScaCap/spring-auto-restdocs/pull/84)

But I want a separate Release with Spring REST Docs v1.1.3 and afterwards we can switch to Spring REST Docs v1.2.0.