### PR TITLE
better javadoc -> asciidoc

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1486,7 +1486,7 @@ and has to be installed with the Maven command shown in the section above.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-07-10 15:09:59 CEST
+    Last updated 2017-07-31 10:29:18 CEST
 </div>
 </div>
 <link rel="stylesheet" href="highlight/styles/github.min.css">

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/OperationAttributeHelper.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/OperationAttributeHelper.java
@@ -131,12 +131,12 @@ public class OperationAttributeHelper {
         return (List<Snippet>) operation.getAttributes().get(ATTRIBUTE_NAME_DEFAULT_SNIPPETS);
     }
 
-    public static String determineLineBreak(Operation operation) {
-        return determineLineBreak(getTemplateFormat(operation));
+    public static String determineForcedLineBreak(Operation operation) {
+        return determineForcedLineBreak(getTemplateFormat(operation));
     }
 
     // necessary until https://github.com/spring-projects/spring-restdocs/issues/351 is fixed
-    public static String determineLineBreak(TemplateFormat templateFormat) {
+    public static String determineForcedLineBreak(TemplateFormat templateFormat) {
         return templateFormat.getId().equals(TemplateFormats.asciidoctor().getId())
                 ? LINE_BREAK_ASCIIDOC : LINE_BREAK_MARKDOWN;
     }

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/javadoc/JavadocUtil.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/javadoc/JavadocUtil.java
@@ -1,29 +1,43 @@
 package capital.scalable.restdocs.javadoc;
 
 public class JavadocUtil {
+    private static String FORCED_LB = "__FLB__";
+    private static String LB = "__LB__";
+
     private JavadocUtil() {
         // util
     }
 
-    public static String convertFromJavadoc(String javadoc, String lineBreak) {
-        String withConvertedLineBreaks = javadoc
+    public static String convertFromJavadoc(String javadoc, String forcedLineBreak) {
+        String converted = javadoc.toString()
+                // line breaks in javadoc are ignored
                 .replace("\n", "")
-                .replace("<br/>", "\n")
-                .replace("<br>", "\n")
-                .replace("<p>", "\n\n")
-                .replace("</p>", "")
-                .trim();
+                // will be replaced with forced line break
+                .replace("<br/>", FORCED_LB)
+                .replace("<br>", FORCED_LB)
+                // will be replaced with normal line break
+                .replace("<p>", LB + LB)
+                .replace("</p>", LB + LB)
+                .replace("<ul>", LB)
+                .replace("</ul>", LB + LB)
+                .replace("<li>", LB + "- ")
+                .replace("</li>", "");
 
-        if (withConvertedLineBreaks.isEmpty()) {
+        if (converted.isEmpty()) {
             return "";
         }
 
-        StringBuilder res = new StringBuilder();
-        for (String line : withConvertedLineBreaks.split("\n")) {
-            res.append(line.trim()).append(lineBreak);
-        }
-        res.delete(res.lastIndexOf(lineBreak), res.length());
+        String res = trimAndFixLineBreak(converted, FORCED_LB, forcedLineBreak);
+        res = trimAndFixLineBreak(res, LB, "\n");
+        return res.toString();
+    }
 
+    private static String trimAndFixLineBreak(String text, String separator, String newSeparator) {
+        StringBuilder res = new StringBuilder();
+        for (String line : text.split(separator)) {
+            res.append(line.trim()).append(newSeparator);
+        }
+        res.delete(res.lastIndexOf(newSeparator), res.length());
         return res.toString();
     }
 }

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/misc/DescriptionSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/misc/DescriptionSnippet.java
@@ -16,7 +16,7 @@
 
 package capital.scalable.restdocs.misc;
 
-import static capital.scalable.restdocs.OperationAttributeHelper.determineLineBreak;
+import static capital.scalable.restdocs.OperationAttributeHelper.determineForcedLineBreak;
 import static capital.scalable.restdocs.OperationAttributeHelper.getHandlerMethod;
 import static capital.scalable.restdocs.OperationAttributeHelper.getJavadocReader;
 import static capital.scalable.restdocs.javadoc.JavadocUtil.convertFromJavadoc;
@@ -49,7 +49,7 @@ public class DescriptionSnippet extends TemplatedSnippet {
             methodComment = "";
         }
 
-        methodComment = convertFromJavadoc(methodComment, determineLineBreak(operation));
+        methodComment = convertFromJavadoc(methodComment, determineForcedLineBreak(operation));
 
         Map<String, Object> model = new HashMap<>();
         model.put(DESCRIPTION, methodComment);

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/javadoc/JavadocUtilTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/javadoc/JavadocUtilTest.java
@@ -7,18 +7,43 @@ import org.junit.Test;
 
 public class JavadocUtilTest {
 
+    private static final String LINE_BREAK_ASCIIDOC = " +\n";
+
     @Test
-    public void convertFromJavadoc() {
-        String actual = "First line is ok" +
+    public void convertLineBreaks() {
+        String actual = "" +
+                "First line is ok" +
                 "<br>  second line should be trimmed  " +
                 "<br/>\n\nthis is just \none\n\n line " +
                 "<p> first paragraph</p>" +
                 "<p> second paragraph \n \n  ";
-        String expected = "First line is ok" +
-                "|LB|second line should be trimmed" +
-                "|LB|this is just one line" +
-                "|LB||LB|first paragraph" +
-                "|LB||LB|second paragraph";
-        assertThat(JavadocUtil.convertFromJavadoc(actual, "|LB|"), is(expected));
+        String expected = "" +
+                "First line is ok" +
+                " +\nsecond line should be trimmed" +
+                " +\nthis is just one line" +
+                "\n\nfirst paragraph\n\n" +
+                "\n\nsecond paragraph";
+        assertThat(JavadocUtil.convertFromJavadoc(actual, LINE_BREAK_ASCIIDOC), is(expected));
+    }
+
+    @Test
+    public void convertBulletedList() {
+        String actual = "" +
+                "<ul>" +
+                "<li>first bullet</li>" +
+                "<li>second bullet</li>" +
+                "</ul>some text" +
+                "<li>standalone li" +
+                "<ul>" +
+                "<li>without end works as well";
+        String expected = "" +
+                "\n" +
+                "\n- first bullet" +
+                "\n- second bullet" +
+                "\n\nsome text" +
+                "\n- standalone li" +
+                "\n" +
+                "\n- without end works as well";
+        assertThat(JavadocUtil.convertFromJavadoc(actual, LINE_BREAK_ASCIIDOC), is(expected));
     }
 }

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/misc/DescriptionSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/misc/DescriptionSnippetTest.java
@@ -16,7 +16,6 @@
 
 package capital.scalable.restdocs.misc;
 
-import static capital.scalable.restdocs.OperationAttributeHelper.determineLineBreak;
 import static capital.scalable.restdocs.misc.DescriptionSnippet.DESCRIPTION;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.Mockito.mock;
@@ -40,22 +39,16 @@ public class DescriptionSnippetTest extends AbstractSnippetTests {
                 "testDescription");
         JavadocReader javadocReader = mock(JavadocReader.class);
         when(javadocReader.resolveMethodComment(TestResource.class, "testDescription"))
-                .thenReturn("Sample method comment<br>\n with newline\n <p>\n and one paragraph\n");
+                .thenReturn("Sample method comment");
 
         this.snippets.expect(DESCRIPTION)
-                .withContents(equalTo("Sample method comment" + lineBreak()
-                        + "with newline" + lineBreak() + lineBreak()
-                        + "and one paragraph"));
+                .withContents(equalTo("Sample method comment"));
 
         new DescriptionSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
                 .attribute(JavadocReader.class.getName(), javadocReader)
                 .request("http://localhost/test")
                 .build());
-    }
-
-    private String lineBreak() {
-        return determineLineBreak(templateFormat);
     }
 
     private static class TestResource {

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/payload/JacksonRequestFieldSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/payload/JacksonRequestFieldSnippetTest.java
@@ -16,7 +16,6 @@
 
 package capital.scalable.restdocs.payload;
 
-import static capital.scalable.restdocs.OperationAttributeHelper.determineLineBreak;
 import static com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY;
 import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME;
 import static java.util.Collections.singletonList;
@@ -72,7 +71,7 @@ public class JacksonRequestFieldSnippetTest extends AbstractSnippetTests {
     public void simpleRequest() throws Exception {
         HandlerMethod handlerMethod = createHandlerMethod("addItem", Item.class);
         mockFieldComment(Item.class, "field1", "A string");
-        mockFieldComment(Item.class, "field2", "An integer<br>\n Very important\n <p>\n field");
+        mockFieldComment(Item.class, "field2", "An integer");
         mockMandatoryConstraint(NotBlank.class, true);
         mockOptionalMessage(Item.class, "field1", "false");
         mockConstraintMessage(Item.class, "field2", "A constraint");
@@ -80,10 +79,7 @@ public class JacksonRequestFieldSnippetTest extends AbstractSnippetTests {
         this.snippets.expectRequestFields().withContents(
                 tableWithHeader("Path", "Type", "Optional", "Description")
                         .row("field1", "String", "false", "A string.")
-                        .row("field2", "Integer", "true", "An integer" + lineBreak()
-                                + "Very important" + lineBreak() + lineBreak()
-                                + "field." + lineBreak()
-                                + "A constraint."));
+                        .row("field2", "Integer", "true", "An integer.\n\nA constraint."));
 
         new JacksonRequestFieldSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
@@ -233,10 +229,6 @@ public class JacksonRequestFieldSnippetTest extends AbstractSnippetTests {
     private HandlerMethod createHandlerMethod(String name, Class<?>... parameterTypes)
             throws NoSuchMethodException {
         return new HandlerMethod(new TestResource(), name, parameterTypes);
-    }
-
-    private String lineBreak() {
-        return determineLineBreak(templateFormat);
     }
 
     private static class TestResource {

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippetTest.java
@@ -45,7 +45,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.restdocs.AbstractSnippetTests;
 import org.springframework.restdocs.snippet.SnippetException;
 import org.springframework.restdocs.templates.TemplateFormat;
-import org.springframework.restdocs.templates.TemplateFormats;
 import org.springframework.web.method.HandlerMethod;
 
 public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
@@ -83,7 +82,7 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
                 tableWithHeader("Path", "Type", "Optional", "Description")
                         .row("field1", "String", "false", "A string.")
                         .row("field2", "Decimal", "true",
-                                "A decimal." + lineBreak() + "A constraint.")));
+                                "A decimal.\n\nA constraint.")));
 
         new JacksonResponseFieldSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
@@ -139,7 +138,7 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
                         tableWithHeader("Path", "Type", "Optional", "Description")
                                 .row("field1", "String", "false", "A string.")
                                 .row("field2", "Decimal", "true",
-                                        "A decimal." + lineBreak() + "A constraint.")));
+                                        "A decimal.\n\nA constraint.")));
 
         new JacksonResponseFieldSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
@@ -162,7 +161,7 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
                 tableWithHeader("Path", "Type", "Optional", "Description")
                         .row("field1", "String", "false", "A string.")
                         .row("field2", "Decimal", "true",
-                                "A decimal." + lineBreak() + "A constraint.")));
+                                "A decimal.\n\nA constraint.")));
 
         new JacksonResponseFieldSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
@@ -253,11 +252,6 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
             return "Standard [paging](#overview-pagination) response where `content` field is"
                     + " list of following objects:\n";
         }
-    }
-
-    private String lineBreak() {
-        return templateFormat.getId().equals(TemplateFormats.asciidoctor().getId())
-                ? " +\n" : "<br>";
     }
 
     private HandlerMethod createHandlerMethod(String responseEntityItem)

--- a/spring-auto-restdocs-example/generated-docs/index.html
+++ b/spring-auto-restdocs-example/generated-docs/index.html
@@ -439,7 +439,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#resources-items">2. Items</a>
 <ul class="sectlevel2">
 <li><a href="#resources-items-get">2.1. Get an item</a></li>
-<li><a href="#resources-items-all">2.2. Get all item</a></li>
+    <li><a href="#resources-items-all">2.2. Get all items</a></li>
 <li><a href="#resources-item-resource-test-add-item">2.3. Add Item</a></li>
 <li><a href="#resources-item-resource-test-update-item">2.4. Update Item</a></li>
 <li><a href="#resources-item-resource-test-delete-item">2.5. Delete Item</a></li>
@@ -632,8 +632,9 @@ switch directions, e.g. <code>?sort=firstname&amp;sort=lastname,asc</code>.</p><
 <td class="tableblock halign-left valign-top"><p class="tableblock">id</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">ID of the item.<br>
-Must be a valid ID.</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">ID of the item.
+    </p>
+        <p class="tableblock">Must be a valid ID.</p></td>
 </tr>
 </tbody>
 </table>
@@ -694,15 +695,17 @@ because the template returns "No data." instead of an empty table.</p>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.text</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.<br>
-Size must be between 2 and 20 inclusive.</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.
+    </p>
+        <p class="tableblock">Size must be between 2 and 20 inclusive.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.number</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.<br>
-Must be at least 1.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.
+    </p>
+        <p class="tableblock">Must be at least 1.<br>
 Must be at most 10.</p></td>
 </tr>
 <tr>
@@ -715,8 +718,9 @@ Must be at most 10.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.decimal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.<br>
-Must be at least 1.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.
+    </p>
+        <p class="tableblock">Must be at least 1.<br>
 Must be at most 10.</p></td>
 </tr>
 <tr>
@@ -729,8 +733,9 @@ Must be at most 10.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.enumType</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.<br>
-Must be one of [ONE, TWO].</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.
+    </p>
+        <p class="tableblock">Must be one of [ONE, TWO].</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">children</p></td>
@@ -791,7 +796,7 @@ Content-Length: 378
 </div>
 </div>
 <div class="sect2">
-<h3 id="resources-items-all"><a class="anchor" href="#resources-items-all"></a><a class="link" href="#resources-items-all">2.2. Get all item</a></h3>
+    <h3 id="resources-items-all"><a class="anchor" href="#resources-items-all"></a><a class="link" href="#resources-items-all">2.2. Get all items</a></h3>
 <div class="paragraph">
 <p><code>GET /items</code></p>
 </div>
@@ -859,15 +864,17 @@ Content-Length: 378
 <td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.text</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.<br>
-Size must be between 2 and 20 inclusive.</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.
+    </p>
+        <p class="tableblock">Size must be between 2 and 20 inclusive.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.number</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.<br>
-Must be at least 1.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.
+    </p>
+        <p class="tableblock">Must be at least 1.<br>
 Must be at most 10.</p></td>
 </tr>
 <tr>
@@ -880,8 +887,9 @@ Must be at most 10.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.decimal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.<br>
-Must be at least 1.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.
+    </p>
+        <p class="tableblock">Must be at least 1.<br>
 Must be at most 10.</p></td>
 </tr>
 <tr>
@@ -894,8 +902,9 @@ Must be at most 10.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.enumType</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.<br>
-Must be one of [ONE, TWO].</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.
+    </p>
+        <p class="tableblock">Must be one of [ONE, TWO].</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">[].children</p></td>
@@ -1012,8 +1021,9 @@ Content-Length: 483
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true<br>
 EN: false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.<br>
-DE: Size must be between 2 and 10 inclusive.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.
+    </p>
+        <p class="tableblock">DE: Size must be between 2 and 10 inclusive.<br>
 EN: Size must be between 4 and 12 inclusive.<br>
 Length must be between 0 and 20 inclusive.</p></td>
 </tr>
@@ -1021,8 +1031,9 @@ Length must be between 0 and 20 inclusive.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Country dependent type of the item.<br>
-DE: Must be one of [klein, groß].<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Country dependent type of the item.
+    </p>
+        <p class="tableblock">DE: Must be one of [klein, groß].<br>
 EN: Must be one of [small, big].<br>
 Size must be between 0 and 1000 inclusive.</p></td>
 </tr>
@@ -1041,7 +1052,7 @@ Size must be between 0 and 1000 inclusive.</p></td>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items' -i -X POST \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer ffc616bc-c84b-4c50-9b5d-37b53372f839' \
+    -H 'Authorization: Bearer d3b8da15-bce2-4def-bd28-2ecc7b00ad0c' \
     -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
@@ -1098,8 +1109,9 @@ Location: /items/2</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock">id</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Item ID.<br>
-Must be a valid ID.</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Item ID.
+    </p>
+        <p class="tableblock">Must be a valid ID.</p></td>
 </tr>
 </tbody>
 </table>
@@ -1133,8 +1145,9 @@ Must be a valid ID.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true<br>
 EN: false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.<br>
-DE: Size must be between 2 and 10 inclusive.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.
+    </p>
+        <p class="tableblock">DE: Size must be between 2 and 10 inclusive.<br>
 EN: Size must be between 4 and 12 inclusive.<br>
 Length must be between 0 and 20 inclusive.</p></td>
 </tr>
@@ -1142,8 +1155,9 @@ Length must be between 0 and 20 inclusive.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Country dependent type of the item.<br>
-DE: Must be one of [klein, groß].<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Country dependent type of the item.
+    </p>
+        <p class="tableblock">DE: Must be one of [klein, groß].<br>
 EN: Must be one of [small, big].<br>
 Size must be between 0 and 1000 inclusive.</p></td>
 </tr>
@@ -1196,15 +1210,17 @@ Size must be between 0 and 1000 inclusive.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.text</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.<br>
-Size must be between 2 and 20 inclusive.</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.
+    </p>
+        <p class="tableblock">Size must be between 2 and 20 inclusive.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.number</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.<br>
-Must be at least 1.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.
+    </p>
+        <p class="tableblock">Must be at least 1.<br>
 Must be at most 10.</p></td>
 </tr>
 <tr>
@@ -1217,8 +1233,9 @@ Must be at most 10.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.decimal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.<br>
-Must be at least 1.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.
+    </p>
+        <p class="tableblock">Must be at least 1.<br>
 Must be at most 10.</p></td>
 </tr>
 <tr>
@@ -1231,8 +1248,9 @@ Must be at most 10.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.enumType</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.<br>
-Must be one of [ONE, TWO].</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.
+    </p>
+        <p class="tableblock">Must be one of [ONE, TWO].</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">children</p></td>
@@ -1255,7 +1273,7 @@ Must be one of [ONE, TWO].</p></td>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X PUT \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer ffc616bc-c84b-4c50-9b5d-37b53372f839' \
+    -H 'Authorization: Bearer d3b8da15-bce2-4def-bd28-2ecc7b00ad0c' \
     -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
@@ -1291,9 +1309,10 @@ Content-Length: 90
 </div>
 <div class="paragraph">
 <p>Deletes item.<br>
-Item must exist.<br>
-<br>
-Non existing items are ignored</p>
+    Item must exist.</p>
+</div>
+    <div class="paragraph">
+        <p>Non existing items are ignored</p>
 </div>
 <div class="sect3">
 <h4 id="_authorization_5"><a class="anchor" href="#_authorization_5"></a><a class="link" href="#_authorization_5">2.5.1. Authorization</a></h4>
@@ -1323,8 +1342,9 @@ Non existing items are ignored</p>
 <td class="tableblock halign-left valign-top"><p class="tableblock">id</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">item ID.<br>
-Must be a valid ID.</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Item ID.
+    </p>
+        <p class="tableblock">Must be a valid ID.</p></td>
 </tr>
 </tbody>
 </table>
@@ -1352,7 +1372,7 @@ Must be a valid ID.</p></td>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X DELETE \
-    -H 'Authorization: Bearer ffc616bc-c84b-4c50-9b5d-37b53372f839'</code></pre>
+    -H 'Authorization: Bearer d3b8da15-bce2-4def-bd28-2ecc7b00ad0c'</code></pre>
 </div>
 </div>
 </div>
@@ -1407,15 +1427,17 @@ X-Frame-Options: DENY</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock">id</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Item ID.<br>
-Must be a valid ID.</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Item ID.
+    </p>
+        <p class="tableblock">Must be a valid ID.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">child</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Child ID.<br>
-DE: Must be at most 2.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Child ID.
+    </p>
+        <p class="tableblock">DE: Must be at most 2.<br>
 EN: Must be at least 1.</p></td>
 </tr>
 </tbody>
@@ -1479,15 +1501,17 @@ EN: Must be at least 1.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.text</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.<br>
-Size must be between 2 and 20 inclusive.</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.
+    </p>
+        <p class="tableblock">Size must be between 2 and 20 inclusive.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.number</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.<br>
-Must be at least 1.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.
+    </p>
+        <p class="tableblock">Must be at least 1.<br>
 Must be at most 10.</p></td>
 </tr>
 <tr>
@@ -1500,8 +1524,9 @@ Must be at most 10.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.decimal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.<br>
-Must be at least 1.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.
+    </p>
+        <p class="tableblock">Must be at least 1.<br>
 Must be at most 10.</p></td>
 </tr>
 <tr>
@@ -1514,8 +1539,9 @@ Must be at most 10.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.enumType</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.<br>
-Must be one of [ONE, TWO].</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.
+    </p>
+        <p class="tableblock">Must be one of [ONE, TWO].</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">children</p></td>
@@ -1606,15 +1632,17 @@ Content-Length: 99
 <td class="tableblock halign-left valign-top"><p class="tableblock">desc</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Lookup on description field.<br>
-Size must be between 0 and 255 inclusive.</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Lookup on description field.
+    </p>
+        <p class="tableblock">Size must be between 0 and 255 inclusive.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">hint</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Lookup hint.<br>
-Must be at least 10.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Lookup hint.
+    </p>
+        <p class="tableblock">Must be at least 10.<br>
 Must be at most 100.</p></td>
 </tr>
 </tbody>
@@ -1675,15 +1703,17 @@ Must be at most 100.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.text</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.<br>
-Size must be between 2 and 20 inclusive.</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.
+    </p>
+        <p class="tableblock">Size must be between 2 and 20 inclusive.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.number</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.<br>
-Must be at least 1.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.
+    </p>
+        <p class="tableblock">Must be at least 1.<br>
 Must be at most 10.</p></td>
 </tr>
 <tr>
@@ -1696,8 +1726,9 @@ Must be at most 10.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.decimal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.<br>
-Must be at least 1.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.
+    </p>
+        <p class="tableblock">Must be at least 1.<br>
 Must be at most 10.</p></td>
 </tr>
 <tr>
@@ -1710,8 +1741,9 @@ Must be at most 10.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.enumType</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.<br>
-Must be one of [ONE, TWO].</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.
+    </p>
+        <p class="tableblock">Must be one of [ONE, TWO].</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">children</p></td>
@@ -1773,14 +1805,14 @@ Content-Length: 625
   } ],
   "pageable" : null,
   "total" : 1,
-  "totalElements" : 1,
   "last" : true,
   "totalPages" : 1,
-  "sort" : null,
-  "first" : true,
-  "numberOfElements" : 1,
+  "totalElements" : 1,
   "size" : 0,
-  "number" : 0
+  "number" : 0,
+  "sort" : null,
+  "numberOfElements" : 1,
+  "first" : true
 }</code></pre>
 </div>
 </div>
@@ -1904,8 +1936,20 @@ Content-Length: 28
 </div>
 <div class="paragraph">
 <p>Executes a command on an item.<br>
-<br>
-This endpoint demos the basic support for @ModelAttribute. Note that the request body is documented as it would be JSON, but it is actually form-urlencoded. Setting the type manually can help to get the right documentation if the automatic document does not produce the right result.</p>
+    This endpoint demos the basic support for @ModelAttribute.</p>
+</div>
+    <div class="paragraph">
+        <p>Notes:</p>
+    </div>
+    <div class="ulist">
+        <ul>
+            <li>
+                <p>the request body is documented as it would be JSON, but it is actually form-urlencoded</p>
+            </li>
+            <li>
+                <p>setting the type manually can help to get the right documentation if the automatic document does not produce the right result.</p>
+            </li>
+        </ul>
 </div>
 <div class="sect3">
 <h4 id="_authorization_9"><a class="anchor" href="#_authorization_9"></a><a class="link" href="#_authorization_9">2.9.1. Authorization</a></h4>
@@ -2036,7 +2080,7 @@ Content-Length: 55
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-05-21 18:21:50 CEST
+    Last updated 2016-11-25 17:33:45 CET
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.1/styles/github.min.css">

--- a/spring-auto-restdocs-example/src/main/asciidoc/items.adoc
+++ b/spring-auto-restdocs-example/src/main/asciidoc/items.adoc
@@ -32,7 +32,7 @@ include::{snippets}/item-resource-test/get-item/http-response.adoc[]
 
 
 [[resources-items-all]]
-=== Get all item
+=== Get all items
 
 `GET /items`
 

--- a/spring-auto-restdocs-example/src/main/java/capital/scalable/restdocs/example/items/ItemResource.java
+++ b/spring-auto-restdocs-example/src/main/java/capital/scalable/restdocs/example/items/ItemResource.java
@@ -85,7 +85,6 @@ public class ItemResource {
 
     /**
      * Lists all items.
-     *
      * @return list of all items
      */
     @RequestMapping
@@ -96,7 +95,7 @@ public class ItemResource {
     /**
      * Adds new item.
      *
-     * @param itemUpdate item information
+     * @param itemUpdate Item information
      * @return response
      */
     @RequestMapping(method = POST)
@@ -134,7 +133,7 @@ public class ItemResource {
      * <p>
      * Non existing items are ignored
      *
-     * @param id item ID
+     * @param id Item ID
      */
     @RequestMapping(value = "{id}", method = DELETE)
     public void deleteItem(@PathVariable("id") @Id String id) {
@@ -189,12 +188,16 @@ public class ItemResource {
 
     /**
      * Executes a command on an item.
-     * <p>
+     * <br>
      * This endpoint demos the basic support for @ModelAttribute.
-     * Note that the request body is documented as it would be JSON,
-     * but it is actually form-urlencoded.
-     * Setting the type manually can help to get the right documentation
-     * if the automatic document does not produce the right result.
+     * <p>
+     * Notes:
+     * <ul>
+     * <li>the request body is documented as it would be JSON,
+     * but it is actually form-urlencoded</li>
+     * <li>setting the type manually can help to get the right documentation
+     * if the automatic document does not produce the right result.</li>
+     * </ul>
      *
      * @param itemId Item ID.
      */


### PR DESCRIPTION
- `<br>` is the only forced line break
- `<p>` is using normal line breaks. if asciidoc or markdown sees `\n\n` it creates new paragraph properly
- support for bullet list `<ul>`, `<li>` using just normal line breaks
- constraints are separated as new paragraph in description field (before was forced line break)