### PR TITLE
support for primitive types

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1486,7 +1486,7 @@ and has to be installed with the Maven command shown in the section above.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-07-10 15:09:59 CEST
+    Last updated 2017-07-31 20:26:55 CEST
 </div>
 </div>
 <link rel="stylesheet" href="highlight/styles/github.min.css">

--- a/docs/index.html
+++ b/docs/index.html
@@ -1486,7 +1486,7 @@ and has to be installed with the Maven command shown in the section above.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-    Last updated 2017-07-31 20:26:55 CEST
+    Last updated 2017-07-31 20:33:00 CEST
 </div>
 </div>
 <link rel="stylesheet" href="highlight/styles/github.min.css">

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/constraints/ConstraintAndGroupDescriptionResolver.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/constraints/ConstraintAndGroupDescriptionResolver.java
@@ -50,7 +50,7 @@ public class ConstraintAndGroupDescriptionResolver implements
             constraintDescription = constraint.getName();
         }
 
-        List<Class> groups = getGroups(constraint);
+        List<Class<?>> groups = getGroups(constraint);
         if (groups.isEmpty()) {
             return constraintDescription;
         }
@@ -65,14 +65,14 @@ public class ConstraintAndGroupDescriptionResolver implements
     }
 
     @Override
-    public List<Class> getGroups(Constraint constraint) {
+    public List<Class<?>> getGroups(Constraint constraint) {
         Object rawGroups = constraint.getConfiguration().get(GROUPS);
         if (!(rawGroups instanceof Class[])) {
             return emptyList();
         }
-        Class[] groups = (Class[]) rawGroups;
+        Class<?>[] groups = (Class[]) rawGroups;
 
-        List<Class> result = new ArrayList<>();
+        List<Class<?>> result = new ArrayList<>();
         Collections.addAll(result, groups);
         return result;
     }

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/constraints/ConstraintReader.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/constraints/ConstraintReader.java
@@ -24,8 +24,6 @@ public interface ConstraintReader {
     String CONSTRAINTS_ATTRIBUTE = "constraints";
     String OPTIONAL_ATTRIBUTE = "optionals";
 
-    boolean isMandatory(Class<?> annotation);
-
     List<String> getConstraintMessages(Class<?> javaBaseClass, String javaFieldName);
 
     List<String> getConstraintMessages(MethodParameter param);

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/constraints/ConstraintReaderImpl.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/constraints/ConstraintReaderImpl.java
@@ -17,13 +17,10 @@
 package capital.scalable.restdocs.constraints;
 
 import static capital.scalable.restdocs.constraints.ConstraintAndGroupDescriptionResolver.VALUE;
-import static capital.scalable.restdocs.constraints.SkippableConstraintResolver
-        .MANDATORY_VALUE_ANNOTATIONS;
 import static capital.scalable.restdocs.util.ObjectUtil.arrayToString;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
-import static org.apache.commons.lang3.ArrayUtils.contains;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.springframework.util.ReflectionUtils.findField;
 
@@ -53,11 +50,6 @@ public class ConstraintReaderImpl implements ConstraintReader {
     @Override
     public List<String> getOptionalMessages(Class<?> javaBaseClass, String javaFieldName) {
         return skippableConstraintResolver.getOptionalMessages(javaFieldName, javaBaseClass);
-    }
-
-    @Override
-    public boolean isMandatory(Class<?> annotation) {
-        return contains(MANDATORY_VALUE_ANNOTATIONS, annotation);
     }
 
     @Override

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/constraints/GroupDescriptionResolver.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/constraints/GroupDescriptionResolver.java
@@ -21,7 +21,7 @@ import java.util.List;
 import org.springframework.restdocs.constraints.Constraint;
 
 public interface GroupDescriptionResolver {
-    List<Class> getGroups(Constraint constraint);
+    List<Class<?>> getGroups(Constraint constraint);
 
-    String resolveGroupDescription(Class group, String constraintDescription);
+    String resolveGroupDescription(Class<?> group, String constraintDescription);
 }

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/constraints/SkippableConstraintResolver.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/constraints/SkippableConstraintResolver.java
@@ -78,7 +78,7 @@ class SkippableConstraintResolver implements MethodParameterConstraintResolver {
 
         for (Constraint constraint : constraints) {
             if (isSkippable(constraint)) {
-                List<Class> groups = getGroups(constraint);
+                List<Class<?>> groups = getGroups(constraint);
 
                 if (groups.isEmpty()) {
                     defaultOptional = "false";
@@ -97,7 +97,7 @@ class SkippableConstraintResolver implements MethodParameterConstraintResolver {
         return result;
     }
 
-    private List<Class> getGroups(Constraint constraint) {
+    private List<Class<?>> getGroups(Constraint constraint) {
         return descriptionResolver.getGroups(constraint);
     }
 

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/FieldDocumentationGenerator.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/FieldDocumentationGenerator.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import capital.scalable.restdocs.constraints.ConstraintReader;
 import capital.scalable.restdocs.javadoc.JavadocReader;
+import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -30,12 +31,16 @@ import org.springframework.restdocs.payload.FieldDescriptor;
 public class FieldDocumentationGenerator {
 
     private final ObjectWriter writer;
+    private final DeserializationConfig deserializationConfig;
     private final JavadocReader javadocReader;
-    private ConstraintReader constraintReader;
+    private final ConstraintReader constraintReader;
 
-    public FieldDocumentationGenerator(ObjectWriter writer, JavadocReader javadocReader,
+    public FieldDocumentationGenerator(ObjectWriter writer,
+            DeserializationConfig deserializationConfig,
+            JavadocReader javadocReader,
             ConstraintReader constraintReader) {
         this.writer = writer;
+        this.deserializationConfig = deserializationConfig;
         this.javadocReader = javadocReader;
         this.constraintReader = constraintReader;
     }
@@ -47,7 +52,7 @@ public class FieldDocumentationGenerator {
 
     public List<FieldDescriptor> generateDocumentation(JavaType type) throws JsonMappingException {
         FieldDocumentationVisitorWrapper visitorWrapper = FieldDocumentationVisitorWrapper.create(
-                javadocReader, constraintReader);
+                javadocReader, constraintReader, deserializationConfig);
         writer.acceptJsonFormatVisitor(type, visitorWrapper);
         return visitorWrapper.getContext().getFields();
     }

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/FieldDocumentationVisitorContext.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/FieldDocumentationVisitorContext.java
@@ -93,7 +93,7 @@ public class FieldDocumentationVisitorContext {
         List<String> optionalMessages = new ArrayList<>();
 
         if (isPrimitive(javaBaseClass, javaFieldName)) {
-            optionalMessages.add("false");
+            optionalMessages.add("true"); // jackson handles null for primitives, keeps the default
             return optionalMessages;
         }
 

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/FieldDocumentationVisitorWrapper.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/FieldDocumentationVisitorWrapper.java
@@ -18,6 +18,7 @@ package capital.scalable.restdocs.jackson;
 
 import capital.scalable.restdocs.constraints.ConstraintReader;
 import capital.scalable.restdocs.javadoc.JavadocReader;
+import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.SerializerProvider;
@@ -52,9 +53,10 @@ public class FieldDocumentationVisitorWrapper implements JsonFormatVisitorWrappe
     }
 
     public static FieldDocumentationVisitorWrapper create(JavadocReader javadocReader,
-            ConstraintReader constraintReader) {
+            ConstraintReader constraintReader, DeserializationConfig deserializationConfig) {
         return new FieldDocumentationVisitorWrapper(
-                new FieldDocumentationVisitorContext(javadocReader, constraintReader), "", null);
+                new FieldDocumentationVisitorContext(javadocReader, constraintReader,
+                        deserializationConfig), "", null);
     }
 
     @Override

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/AbstractJacksonFieldSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/AbstractJacksonFieldSnippet.java
@@ -77,7 +77,7 @@ abstract class AbstractJacksonFieldSnippet extends StandardTableSnippet implemen
         if (signatureType != null) {
             try {
                 for (Type type : resolveActualTypes(signatureType)) {
-                    resolveFieldDescriptors(fieldDescriptors, type, writer, typeFactory,
+                    resolveFieldDescriptors(fieldDescriptors, type, objectMapper,
                             javadocReader, constraintReader);
                 }
             } catch (JsonMappingException e) {
@@ -121,11 +121,13 @@ abstract class AbstractJacksonFieldSnippet extends StandardTableSnippet implemen
     }
 
     private void resolveFieldDescriptors(Map<String, FieldDescriptor> fieldDescriptors,
-            Type type, ObjectWriter writer, TypeFactory typeFactory, JavadocReader javadocReader,
+            Type type, ObjectMapper objectMapper, JavadocReader javadocReader,
             ConstraintReader constraintReader) throws JsonMappingException {
-        FieldDocumentationGenerator generator = new FieldDocumentationGenerator(writer,
-                javadocReader, constraintReader);
-        List<FieldDescriptor> descriptors = generator.generateDocumentation(type, typeFactory);
+        FieldDocumentationGenerator generator = new FieldDocumentationGenerator(
+                objectMapper.writer(), objectMapper.getDeserializationConfig(), javadocReader,
+                constraintReader);
+        List<FieldDescriptor> descriptors = generator.generateDocumentation(type,
+                objectMapper.getTypeFactory());
         for (FieldDescriptor descriptor : descriptors) {
             if (fieldDescriptors.get(descriptor.getPath()) == null) {
                 fieldDescriptors.put(descriptor.getPath(), descriptor);

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/AbstractParameterSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/AbstractParameterSnippet.java
@@ -22,8 +22,8 @@ import static capital.scalable.restdocs.OperationAttributeHelper.getJavadocReade
 import static capital.scalable.restdocs.constraints.ConstraintReader.CONSTRAINTS_ATTRIBUTE;
 import static capital.scalable.restdocs.constraints.ConstraintReader.OPTIONAL_ATTRIBUTE;
 import static capital.scalable.restdocs.util.FieldDescriptorUtil.assertAllDocumented;
+import static capital.scalable.restdocs.util.TypeUtil.determineTypeName;
 import static java.util.Collections.singletonList;
-import static org.apache.commons.lang3.ClassUtils.primitiveToWrapper;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.util.StringUtils.hasLength;
 
@@ -91,22 +91,6 @@ abstract class AbstractParameterSnippet<A extends Annotation> extends StandardTa
         descriptor.attributes(constraints, optionals);
 
         fieldDescriptors.add(descriptor);
-    }
-
-    private String determineTypeName(Class<?> parameterType) {
-        // returning the same as FieldDocumentationVisitorWrapper
-        switch (primitiveToWrapper(parameterType).getCanonicalName()) {
-        case "java.lang.Long":
-        case "java.lang.Integer":
-        case "java.lang.Short":
-            return "Integer";
-        case "java.lang.Float":
-        case "java.lang.Double":
-        case "java.lang.BigDecimal":
-            return "Decimal";
-        default:
-            return parameterType.getSimpleName();
-        }
     }
 
     protected Attribute constraintAttribute(MethodParameter param,

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/PathParametersSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/PathParametersSnippet.java
@@ -38,8 +38,10 @@ public class PathParametersSnippet extends AbstractParameterSnippet<PathVariable
     }
 
     @Override
-    protected boolean isRequired(PathVariable annot) {
-        return true;
+    protected boolean isRequired(MethodParameter param, PathVariable annot) {
+        return param.getParameterType().isPrimitive()
+                ? true // spring disallows null for primitive
+                : annot.required();
     }
 
     @Override

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/RequestParametersSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/RequestParametersSnippet.java
@@ -18,6 +18,7 @@ package capital.scalable.restdocs.request;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ValueConstants;
 
 public class RequestParametersSnippet extends AbstractParameterSnippet<RequestParam> {
 
@@ -41,7 +42,7 @@ public class RequestParametersSnippet extends AbstractParameterSnippet<RequestPa
     @Override
     protected boolean isRequired(MethodParameter param, RequestParam annot) {
         return param.getParameterType().isPrimitive()
-                ? true // spring disallows null for primitive
+                ? ValueConstants.DEFAULT_NONE.equals(annot.defaultValue())
                 : annot.required();
     }
 

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/RequestParametersSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/RequestParametersSnippet.java
@@ -39,8 +39,10 @@ public class RequestParametersSnippet extends AbstractParameterSnippet<RequestPa
     }
 
     @Override
-    protected boolean isRequired(RequestParam annot) {
-        return annot.required();
+    protected boolean isRequired(MethodParameter param, RequestParam annot) {
+        return param.getParameterType().isPrimitive()
+                ? true // spring disallows null for primitive
+                : annot.required();
     }
 
     @Override

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/snippet/StandardTableSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/snippet/StandardTableSnippet.java
@@ -85,13 +85,8 @@ public abstract class StandardTableSnippet extends TemplatedSnippet {
         String description = convertFromJavadoc(toString(descriptor.getDescription()),
                 forcedLineBreak);
 
-        List<String> optionalMessages = (List<String>) descriptor.getAttributes().get(
-                OPTIONAL_ATTRIBUTE);
-        String optional = "" + join(optionalMessages, forcedLineBreak);
-
-        List<String> constraints = (List<String>) descriptor.getAttributes().get(
-                CONSTRAINTS_ATTRIBUTE);
-
+        String optional = resolveOptional(descriptor, forcedLineBreak);
+        List<String> constraints = resolveConstraints(descriptor);
         description = joinAndFormat(description, constraints, forcedLineBreak);
 
         Map<String, Object> model = new HashMap<>();
@@ -100,6 +95,17 @@ public abstract class StandardTableSnippet extends TemplatedSnippet {
         model.put("optional", optional);
         model.put("description", description);
         return model;
+    }
+
+    private List<String> resolveConstraints(FieldDescriptor descriptor) {
+        return (List<String>) descriptor.getAttributes()
+                .get(CONSTRAINTS_ATTRIBUTE);
+    }
+
+    private String resolveOptional(FieldDescriptor descriptor, String forcedLineBreak) {
+        List<String> optionalMessages = (List<String>) descriptor.getAttributes()
+                .get(OPTIONAL_ATTRIBUTE);
+        return "" + join(optionalMessages, forcedLineBreak);
     }
 
     private String toString(Object value) {

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/util/FieldUtil.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/util/FieldUtil.java
@@ -27,6 +27,10 @@ public final class FieldUtil {
      * Creates a field name from getter
      */
     public static String fromGetter(String javaMethodName) {
+        if (!isGetter(javaMethodName)) {
+            return javaMethodName;
+        }
+
         int cut = javaMethodName.startsWith("get") ? "get".length() : "is".length();
         return uncapitalize(javaMethodName.substring(cut, javaMethodName.length()));
     }

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/util/FieldUtil.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/util/FieldUtil.java
@@ -23,12 +23,18 @@ public final class FieldUtil {
         // utils
     }
 
+    /**
+     * Creates a field name from getter
+     */
     public static String fromGetter(String javaMethodName) {
         int cut = javaMethodName.startsWith("get") ? "get".length() : "is".length();
         return uncapitalize(javaMethodName.substring(cut, javaMethodName.length()));
     }
 
-    public static boolean isGetter(String javaFieldName) {
-        return javaFieldName.startsWith("get") || javaFieldName.startsWith("is");
+    /**
+     * Determines if method is getter
+     */
+    public static boolean isGetter(String javaMethodName) {
+        return javaMethodName.startsWith("get") || javaMethodName.startsWith("is");
     }
 }

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/util/TypeUtil.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/util/TypeUtil.java
@@ -1,0 +1,33 @@
+package capital.scalable.restdocs.util;
+
+import static org.apache.commons.lang3.ClassUtils.primitiveToWrapper;
+
+public class TypeUtil {
+    private TypeUtil() {
+        // util
+    }
+
+    public static String determineTypeName(Class<?> type) {
+        // should return the same as FieldDocumentationVisitorWrapper
+        switch (primitiveToWrapper(type).getCanonicalName()) {
+        case "java.lang.Byte":
+        case "java.lang.Short":
+        case "java.lang.Long":
+        case "java.lang.Integer":
+        case "java.math.BigInteger":
+            return "Integer";
+        case "java.lang.Float":
+        case "java.lang.Double":
+        case "java.math.BigDecimal":
+            return "Decimal";
+        case "java.lang.Character":
+            return "String";
+        case "java.lang.Boolean":
+            return "Boolean";
+        default:
+            return type.getSimpleName();
+        }
+    }
+
+
+}

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/util/TypeUtil.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/util/TypeUtil.java
@@ -1,6 +1,12 @@
 package capital.scalable.restdocs.util;
 
+import static capital.scalable.restdocs.util.FieldUtil.fromGetter;
+import static capital.scalable.restdocs.util.FieldUtil.isGetter;
 import static org.apache.commons.lang3.ClassUtils.primitiveToWrapper;
+
+import java.lang.reflect.Field;
+
+import org.springframework.util.ReflectionUtils;
 
 public class TypeUtil {
     private TypeUtil() {
@@ -29,5 +35,11 @@ public class TypeUtil {
         }
     }
 
-
+    public static boolean isPrimitive(Class<?> javaBaseClass, String javaFieldName) {
+        Field field = ReflectionUtils.findField(javaBaseClass, javaFieldName);
+        if (field == null && isGetter(javaFieldName)) {
+            field = ReflectionUtils.findField(javaBaseClass, fromGetter(javaFieldName));
+        }
+        return field != null ? field.getType().isPrimitive() : false;
+    }
 }

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/constraints/ConstraintAndGroupDescriptionResolverTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/constraints/ConstraintAndGroupDescriptionResolverTest.java
@@ -194,7 +194,7 @@ public class ConstraintAndGroupDescriptionResolverTest {
         Constraint constraint =
                 new Constraint("Constraint", Collections.<String, Object>emptyMap());
         // when
-        List<Class> groups = resolver.getGroups(constraint);
+        List<Class<?>> groups = resolver.getGroups(constraint);
         // then
         assertThat(groups.size(), is(0));
     }
@@ -206,7 +206,7 @@ public class ConstraintAndGroupDescriptionResolverTest {
         configuration.put(GROUPS, new Class<?>[]{Update.class, Create.class});
         Constraint constraint = new Constraint("Constraint", configuration);
         // when
-        List<Class> groups = resolver.getGroups(constraint);
+        List<Class<?>> groups = resolver.getGroups(constraint);
         // then
         assertThat(groups.size(), is(2));
         assertThat(groups.get(0), equalTo((Class) Update.class));

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/constraints/ConstraintReaderImplTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/constraints/ConstraintReaderImplTest.java
@@ -73,12 +73,16 @@ public class ConstraintReaderImplTest {
 
         messages = reader.getConstraintMessages(Constraintz.class, "num");
         assertThat(messages.size(), is(1));
-        // fallback
         assertThat(messages.get(0), is("Must be at most 10 (groups: [UnresolvedGroup])"));
+
+        messages = reader.getConstraintMessages(Constraintz.class, "bool");
+        assertThat(messages.size(), is(0));
+
+        messages = reader.getConstraintMessages(Constraintz.class, "str");
+        assertThat(messages.size(), is(0)); // array
 
         messages = reader.getConstraintMessages(Constraintz.class, "enum1");
         assertThat(messages.size(), is(1));
-        // fallback
         assertThat(messages.get(0), is("Must be one of [ONE, TWO]"));
 
         messages = reader.getConstraintMessages(Constraintz.class, "enum2");
@@ -114,6 +118,12 @@ public class ConstraintReaderImplTest {
         assertThat(messages.get(0), is("false (create)"));
 
         messages = reader.getOptionalMessages(Constraintz.class, "num");
+        assertThat(messages.size(), is(0));
+
+        messages = reader.getOptionalMessages(Constraintz.class, "bool");
+        assertThat(messages.size(), is(0));
+
+        messages = reader.getOptionalMessages(Constraintz.class, "str");
         assertThat(messages.size(), is(0));
 
         messages = reader.getOptionalMessages(Constraintz.class, "enum1");
@@ -167,6 +177,10 @@ public class ConstraintReaderImplTest {
 
         @Max(value = 10, groups = UnresolvedGroup.class)
         private long num;
+
+        private boolean bool;
+
+        private char[] str;
 
         private Enum1 enum1;
 

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/constraints/ConstraintReaderImplTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/constraints/ConstraintReaderImplTest.java
@@ -26,7 +26,6 @@ import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Null;
-import javax.validation.constraints.Size;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -40,18 +39,6 @@ import org.springframework.core.MethodParameter;
 public class ConstraintReaderImplTest {
 
     private ConstraintReader reader = new ConstraintReaderImpl();
-
-    @Test
-    public void isMandatory() {
-        assertThat(reader.isMandatory(NotNull.class), is(true));
-        assertThat(reader.isMandatory(NotBlank.class), is(true));
-        assertThat(reader.isMandatory(NotEmpty.class), is(true));
-
-        // sanity check
-        assertThat(reader.isMandatory(Size.class), is(false));
-        assertThat(reader.isMandatory(Override.class), is(false));
-        assertThat(reader.isMandatory(OneOf.class), is(false));
-    }
 
     @Test
     public void getConstraintMessages() {

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/jackson/FieldDocumentationGeneratorTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/jackson/FieldDocumentationGeneratorTest.java
@@ -122,11 +122,11 @@ public class FieldDocumentationGeneratorTest {
         assertThat(fieldDescriptions.get(0),
                 is(descriptor("stringField", "Array", "A string", "true")));
         assertThat(fieldDescriptions.get(1),
-                is(descriptor("booleanField", "Boolean", "A boolean", "false")));
+                is(descriptor("booleanField", "Boolean", "A boolean", "true")));
         assertThat(fieldDescriptions.get(2),
-                is(descriptor("numberField1", "Integer", "An integer", "false")));
+                is(descriptor("numberField1", "Integer", "An integer", "true")));
         assertThat(fieldDescriptions.get(3),
-                is(descriptor("numberField2", "Decimal", "A decimal", "false")));
+                is(descriptor("numberField2", "Decimal", "A decimal", "true")));
     }
 
     @Test

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/jackson/FieldDocumentationGeneratorTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/jackson/FieldDocumentationGeneratorTest.java
@@ -48,6 +48,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.hibernate.validator.constraints.Length;
@@ -76,7 +77,8 @@ public class FieldDocumentationGeneratorTest {
         ConstraintReader constraintReader = mock(ConstraintReader.class);
 
         FieldDocumentationGenerator generator =
-                new FieldDocumentationGenerator(mapper.writer(), javadocReader, constraintReader);
+                new FieldDocumentationGenerator(mapper.writer(), mapper.getDeserializationConfig(),
+                        javadocReader, constraintReader);
         Type type = BasicTypes.class;
 
         // when
@@ -111,7 +113,8 @@ public class FieldDocumentationGeneratorTest {
         ConstraintReader constraintReader = mock(ConstraintReader.class);
 
         FieldDocumentationGenerator generator =
-                new FieldDocumentationGenerator(mapper.writer(), javadocReader, constraintReader);
+                new FieldDocumentationGenerator(mapper.writer(),
+                        mapper.getDeserializationConfig(), javadocReader, constraintReader);
         Type type = PrimitiveTypes.class;
 
         // when
@@ -127,6 +130,25 @@ public class FieldDocumentationGeneratorTest {
                 is(descriptor("numberField1", "Integer", "An integer", "true")));
         assertThat(fieldDescriptions.get(3),
                 is(descriptor("numberField2", "Decimal", "A decimal", "true")));
+
+        // when change deserialization config
+        mapper.configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, true);
+        generator = new FieldDocumentationGenerator(mapper.writer(),
+                mapper.getDeserializationConfig(), javadocReader, constraintReader);
+
+        // when
+        fieldDescriptions = cast(generator.generateDocumentation(type, mapper.getTypeFactory()));
+
+        // then
+        assertThat(fieldDescriptions.size(), is(4));
+        assertThat(fieldDescriptions.get(0),
+                is(descriptor("stringField", "Array", "A string", "true"))); // array
+        assertThat(fieldDescriptions.get(1),
+                is(descriptor("booleanField", "Boolean", "A boolean", "false")));
+        assertThat(fieldDescriptions.get(2),
+                is(descriptor("numberField1", "Integer", "An integer", "false")));
+        assertThat(fieldDescriptions.get(3),
+                is(descriptor("numberField2", "Decimal", "A decimal", "false")));
     }
 
     @Test
@@ -150,7 +172,8 @@ public class FieldDocumentationGeneratorTest {
         ConstraintReader constraintReader = mock(ConstraintReader.class);
 
         FieldDocumentationGenerator generator =
-                new FieldDocumentationGenerator(mapper.writer(), javadocReader, constraintReader);
+                new FieldDocumentationGenerator(mapper.writer(),
+                        mapper.getDeserializationConfig(), javadocReader, constraintReader);
         Type type = ComposedTypes.class;
 
         // when
@@ -199,7 +222,8 @@ public class FieldDocumentationGeneratorTest {
         ConstraintReader constraintReader = mock(ConstraintReader.class);
 
         FieldDocumentationGenerator generator =
-                new FieldDocumentationGenerator(mapper.writer(), javadocReader, constraintReader);
+                new FieldDocumentationGenerator(mapper.writer(),
+                        mapper.getDeserializationConfig(), javadocReader, constraintReader);
         Type type = FirstLevel.class;
 
         // when
@@ -236,7 +260,8 @@ public class FieldDocumentationGeneratorTest {
         ConstraintReader constraintReader = mock(ConstraintReader.class);
 
         FieldDocumentationGenerator generator =
-                new FieldDocumentationGenerator(mapper.writer(), javadocReader, constraintReader);
+                new FieldDocumentationGenerator(mapper.writer(),
+                        mapper.getDeserializationConfig(), javadocReader, constraintReader);
         Type type = RecursiveType.class;
 
         // when
@@ -269,7 +294,8 @@ public class FieldDocumentationGeneratorTest {
         mapper.registerModule(testModule);
 
         FieldDocumentationGenerator generator =
-                new FieldDocumentationGenerator(mapper.writer(), javadocReader, constraintReader);
+                new FieldDocumentationGenerator(mapper.writer(),
+                        mapper.getDeserializationConfig(), javadocReader, constraintReader);
         Type type = ExternalSerializer.class;
 
         // when
@@ -300,7 +326,8 @@ public class FieldDocumentationGeneratorTest {
         ConstraintReader constraintReader = mock(ConstraintReader.class);
 
         FieldDocumentationGenerator generator =
-                new FieldDocumentationGenerator(mapper.writer(), javadocReader, constraintReader);
+                new FieldDocumentationGenerator(mapper.writer(),
+                        mapper.getDeserializationConfig(), javadocReader, constraintReader);
         Type type = JsonAnnotations.class;
 
         // when
@@ -347,7 +374,8 @@ public class FieldDocumentationGeneratorTest {
                 .thenReturn("A secured flag");
 
         FieldDocumentationGenerator generator =
-                new FieldDocumentationGenerator(mapper.writer(), javadocReader, constraintReader);
+                new FieldDocumentationGenerator(mapper.writer(),
+                        mapper.getDeserializationConfig(), javadocReader, constraintReader);
         Type type = FieldCommentResolution.class;
 
         // when
@@ -392,7 +420,8 @@ public class FieldDocumentationGeneratorTest {
                 .thenReturn(singletonList("false"));
 
         FieldDocumentationGenerator generator =
-                new FieldDocumentationGenerator(mapper.writer(), javadocReader, constraintReader);
+                new FieldDocumentationGenerator(mapper.writer(),
+                        mapper.getDeserializationConfig(), javadocReader, constraintReader);
         Type type = ConstraintResolution.class;
 
         // when

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/payload/JacksonRequestFieldSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/payload/JacksonRequestFieldSnippetTest.java
@@ -73,7 +73,6 @@ public class JacksonRequestFieldSnippetTest extends AbstractSnippetTests {
         HandlerMethod handlerMethod = createHandlerMethod("addItem", Item.class);
         mockFieldComment(Item.class, "field1", "A string");
         mockFieldComment(Item.class, "field2", "An integer<br>\n Very important\n <p>\n field");
-        mockMandatoryConstraint(NotBlank.class, true);
         mockOptionalMessage(Item.class, "field1", "false");
         mockConstraintMessage(Item.class, "field2", "A constraint");
 
@@ -219,10 +218,6 @@ public class JacksonRequestFieldSnippetTest extends AbstractSnippetTests {
     private void mockOptionalMessage(Class<?> type, String fieldName, String comment) {
         when(constraintReader.getOptionalMessages(type, fieldName))
                 .thenReturn(singletonList(comment));
-    }
-
-    private void mockMandatoryConstraint(Class<?> annotation, boolean mandatory) {
-        when(constraintReader.isMandatory(annotation)).thenReturn(mandatory);
     }
 
     private void mockFieldComment(Class<?> type, String fieldName, String comment) {

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippetTest.java
@@ -75,7 +75,6 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
         HandlerMethod handlerMethod = createHandlerMethod("getItem");
         mockFieldComment(Item.class, "field1", "A string");
         mockFieldComment(Item.class, "field2", "A decimal");
-        mockMandatoryConstraint(NotBlank.class, true);
         mockOptionalMessage(Item.class, "field1", "false");
         mockConstraintMessage(Item.class, "field2", "A constraint");
 
@@ -129,8 +128,6 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
         HandlerMethod handlerMethod = createHandlerMethod("pagedItems");
         mockFieldComment(Item.class, "field1", "A string");
         mockFieldComment(Item.class, "field2", "A decimal");
-
-        mockMandatoryConstraint(NotBlank.class, true);
         mockOptionalMessage(Item.class, "field1", "false");
         mockConstraintMessage(Item.class, "field2", "A constraint");
 
@@ -154,7 +151,6 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
         HandlerMethod handlerMethod = createHandlerMethod("responseEntityItem");
         mockFieldComment(Item.class, "field1", "A string");
         mockFieldComment(Item.class, "field2", "A decimal");
-        mockMandatoryConstraint(NotBlank.class, true);
         mockOptionalMessage(Item.class, "field1", "false");
         mockConstraintMessage(Item.class, "field2", "A constraint");
 
@@ -234,10 +230,6 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
     private void mockOptionalMessage(Class<?> type, String fieldName, String comment) {
         when(constraintReader.getOptionalMessages(type, fieldName))
                 .thenReturn(singletonList(comment));
-    }
-
-    private void mockMandatoryConstraint(Class<?> annotation, boolean mandatory) {
-        when(constraintReader.isMandatory(annotation)).thenReturn(mandatory);
     }
 
     private void mockFieldComment(Class<?> type, String fieldName, String comment) {

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/PathParametersSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/PathParametersSnippetTest.java
@@ -61,13 +61,13 @@ public class PathParametersSnippetTest extends AbstractSnippetTests {
         initParameters(handlerMethod);
         mockParamComment("addItem", "id", "An integer");
         mockParamComment("addItem", "otherId", "A string");
-        mockParamComment("addItem", "subSubId", "An integer");
+        mockParamComment("addItem", "partId", "An integer");
 
         this.snippets.expectPathParameters().withContents(
                 tableWithHeader("Parameter", "Type", "Optional", "Description")
                         .row("id", "Integer", "false", "An integer.")
                         .row("subid", "String", "false", "A string.")
-                        .row("subSubId", "Integer", "false", "An integer."));
+                        .row("partId", "Integer", "false", "An integer."));
 
         new PathParametersSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
@@ -89,11 +89,13 @@ public class PathParametersSnippetTest extends AbstractSnippetTests {
 
     @Test
     public void failOnUndocumentedParams() throws Exception {
-        HandlerMethod handlerMethod = createHandlerMethod("addItem", Integer.class, String.class);
+        HandlerMethod handlerMethod = createHandlerMethod("addItem", Integer.class, String.class,
+                int.class);
         initParameters(handlerMethod);
 
         thrown.expect(SnippetException.class);
-        thrown.expectMessage("Following path parameters were not documented: [id, subid]");
+        thrown.expectMessage(
+                "Following path parameters were not documented: [id, subid, partId]");
 
         new PathParametersSnippet().failOnUndocumentedParams(true).document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
@@ -120,10 +122,10 @@ public class PathParametersSnippetTest extends AbstractSnippetTests {
 
     private static class TestResource {
 
-        @RequestMapping(value = "/items/{id}/subitem/{subid}/{subSubId}")
+        @RequestMapping(value = "/items/{id}/subitem/{subid}/{partId}")
         public void addItem(@PathVariable Integer id,
                 @PathVariable("subid") String otherId,
-                @PathVariable(required = false) int subSubId) { // required anyway
+                @PathVariable(required = false) int partId) { // required anyway
             // NOOP
         }
 

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/PathParametersSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/PathParametersSnippetTest.java
@@ -56,15 +56,18 @@ public class PathParametersSnippetTest extends AbstractSnippetTests {
 
     @Test
     public void simpleRequest() throws Exception {
-        HandlerMethod handlerMethod = createHandlerMethod("addItem", Integer.class, String.class);
+        HandlerMethod handlerMethod = createHandlerMethod("addItem", Integer.class, String.class,
+                int.class);
         initParameters(handlerMethod);
         mockParamComment("addItem", "id", "An integer");
         mockParamComment("addItem", "otherId", "A string");
+        mockParamComment("addItem", "subSubId", "An integer");
 
         this.snippets.expectPathParameters().withContents(
                 tableWithHeader("Parameter", "Type", "Optional", "Description")
                         .row("id", "Integer", "false", "An integer.")
-                        .row("subid", "String", "false", "A string."));
+                        .row("subid", "String", "false", "A string.")
+                        .row("subSubId", "Integer", "false", "An integer."));
 
         new PathParametersSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
@@ -117,8 +120,10 @@ public class PathParametersSnippetTest extends AbstractSnippetTests {
 
     private static class TestResource {
 
-        @RequestMapping(value = "/items/{id}/subitem/{subid}")
-        public void addItem(@PathVariable Integer id, @PathVariable("subid") String otherId) {
+        @RequestMapping(value = "/items/{id}/subitem/{subid}/{subSubId}")
+        public void addItem(@PathVariable Integer id,
+                @PathVariable("subid") String otherId,
+                @PathVariable(required = false) int subSubId) { // required anyway
             // NOOP
         }
 

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/RequestParametersSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/RequestParametersSnippetTest.java
@@ -56,15 +56,17 @@ public class RequestParametersSnippetTest extends AbstractSnippetTests {
     @Test
     public void simpleRequest() throws Exception {
         HandlerMethod handlerMethod = createHandlerMethod("searchItem", Integer.class,
-                String.class);
+                String.class, int.class);
         initParameters(handlerMethod);
         mockParamComment("searchItem", "type", "An integer");
         mockParamComment("searchItem", "description", "A string");
+        mockParamComment("searchItem", "order", "An integer");
 
         this.snippets.expectRequestParameters().withContents(
                 tableWithHeader("Parameter", "Type", "Optional", "Description")
                         .row("type", "Integer", "false", "An integer.")
-                        .row("text", "String", "true", "A string."));
+                        .row("text", "String", "true", "A string.")
+                        .row("order", "Integer", "false", "An integer."));
 
         new RequestParametersSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
@@ -121,7 +123,8 @@ public class RequestParametersSnippetTest extends AbstractSnippetTests {
 
         @RequestMapping(value = "/items/search")
         public void searchItem(@RequestParam Integer type,
-                @RequestParam(value = "text", required = false) String description) {
+                @RequestParam(value = "text", required = false) String description,
+                @RequestParam(required = false) int order) { // required anyway
             // NOOP
         }
 

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/RequestParametersSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/RequestParametersSnippetTest.java
@@ -90,11 +90,11 @@ public class RequestParametersSnippetTest extends AbstractSnippetTests {
     @Test
     public void failOnUndocumentedParams() throws Exception {
         HandlerMethod handlerMethod = createHandlerMethod("searchItem", Integer.class,
-                String.class);
+                String.class, int.class);
         initParameters(handlerMethod);
 
         thrown.expect(SnippetException.class);
-        thrown.expectMessage("Following query parameters were not documented: [type, text]");
+        thrown.expectMessage("Following query parameters were not documented: [type, text, order]");
 
         new RequestParametersSnippet().failOnUndocumentedParams(true).document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/util/FieldDescriptorUtilTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/util/FieldDescriptorUtilTest.java
@@ -1,0 +1,30 @@
+package capital.scalable.restdocs.util;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.snippet.SnippetException;
+
+public class FieldDescriptorUtilTest {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void assertAllDocumented() throws Exception {
+        List<FieldDescriptor> fields = new ArrayList<>();
+        fields.add(fieldWithPath("1").description(""));
+        fields.add(fieldWithPath("2").description("something"));
+        fields.add(fieldWithPath("2"));
+
+        thrown.expect(SnippetException.class);
+        thrown.expectMessage("Following fields were not documented: [1, 2]");
+
+        FieldDescriptorUtil.assertAllDocumented(fields, "fields");
+    }
+}

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/util/FieldUtilTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/util/FieldUtilTest.java
@@ -1,0 +1,24 @@
+package capital.scalable.restdocs.util;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class FieldUtilTest {
+    @Test
+    public void fromGetter() throws Exception {
+        assertThat(FieldUtil.fromGetter("GetField"), is("GetField"));
+        assertThat(FieldUtil.fromGetter("getField"), is("field"));
+        assertThat(FieldUtil.fromGetter("IsField"), is("IsField"));
+        assertThat(FieldUtil.fromGetter("isField"), is("field"));
+    }
+
+    @Test
+    public void isGetter() throws Exception {
+        assertThat(FieldUtil.isGetter("GetField"), is(false));
+        assertThat(FieldUtil.isGetter("getField"), is(true));
+        assertThat(FieldUtil.isGetter("IsField"), is(false));
+        assertThat(FieldUtil.isGetter("isField"), is(true));
+    }
+}

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/util/ObjectUtilTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/util/ObjectUtilTest.java
@@ -1,0 +1,13 @@
+package capital.scalable.restdocs.util;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class ObjectUtilTest {
+    @Test
+    public void arrayToString() throws Exception {
+        assertThat(ObjectUtil.arrayToString(new Object[]{"1", 2, "3"}), is("[1, 2, 3]"));
+    }
+}

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/util/TypeUtilTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/util/TypeUtilTest.java
@@ -1,0 +1,33 @@
+package capital.scalable.restdocs.util;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import org.junit.Test;
+
+public class TypeUtilTest {
+    @Test
+    public void determineTypeName() throws Exception {
+        assertThat(TypeUtil.determineTypeName(byte.class), is("Integer"));
+        assertThat(TypeUtil.determineTypeName(Byte.class), is("Integer"));
+        assertThat(TypeUtil.determineTypeName(short.class), is("Integer"));
+        assertThat(TypeUtil.determineTypeName(Short.class), is("Integer"));
+        assertThat(TypeUtil.determineTypeName(long.class), is("Integer"));
+        assertThat(TypeUtil.determineTypeName(Long.class), is("Integer"));
+        assertThat(TypeUtil.determineTypeName(int.class), is("Integer"));
+        assertThat(TypeUtil.determineTypeName(Integer.class), is("Integer"));
+        assertThat(TypeUtil.determineTypeName(BigInteger.class), is("Integer"));
+        assertThat(TypeUtil.determineTypeName(float.class), is("Decimal"));
+        assertThat(TypeUtil.determineTypeName(Float.class), is("Decimal"));
+        assertThat(TypeUtil.determineTypeName(double.class), is("Decimal"));
+        assertThat(TypeUtil.determineTypeName(Double.class), is("Decimal"));
+        assertThat(TypeUtil.determineTypeName(BigDecimal.class), is("Decimal"));
+        assertThat(TypeUtil.determineTypeName(char.class), is("String"));
+        assertThat(TypeUtil.determineTypeName(Character.class), is("String"));
+        assertThat(TypeUtil.determineTypeName(boolean.class), is("Boolean"));
+        assertThat(TypeUtil.determineTypeName(Boolean.class), is("Boolean"));
+    }
+}

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/util/TypeUtilTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/util/TypeUtilTest.java
@@ -30,4 +30,15 @@ public class TypeUtilTest {
         assertThat(TypeUtil.determineTypeName(boolean.class), is("Boolean"));
         assertThat(TypeUtil.determineTypeName(Boolean.class), is("Boolean"));
     }
+
+    @Test
+    public void isPrimitive() throws Exception {
+        assertThat(TypeUtil.isPrimitive(TestClass.class, "primitive"), is(true));
+        assertThat(TypeUtil.isPrimitive(TestClass.class, "wrapper"), is(false));
+    }
+
+    static class TestClass {
+        private boolean primitive;
+        private Boolean wrapper;
+    }
 }

--- a/spring-auto-restdocs-example/generated-docs/index.html
+++ b/spring-auto-restdocs-example/generated-docs/index.html
@@ -1041,7 +1041,7 @@ Size must be between 0 and 1000 inclusive.</p></td>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items' -i -X POST \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer ffc616bc-c84b-4c50-9b5d-37b53372f839' \
+    -H 'Authorization: Bearer d0936e63-7212-4335-810c-a185d30389ac' \
     -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
@@ -1255,7 +1255,7 @@ Must be one of [ONE, TWO].</p></td>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X PUT \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer ffc616bc-c84b-4c50-9b5d-37b53372f839' \
+    -H 'Authorization: Bearer d0936e63-7212-4335-810c-a185d30389ac' \
     -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
@@ -1352,7 +1352,7 @@ Must be a valid ID.</p></td>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X DELETE \
-    -H 'Authorization: Bearer ffc616bc-c84b-4c50-9b5d-37b53372f839'</code></pre>
+    -H 'Authorization: Bearer d0936e63-7212-4335-810c-a185d30389ac'</code></pre>
 </div>
 </div>
 </div>
@@ -1773,14 +1773,14 @@ Content-Length: 625
   } ],
   "pageable" : null,
   "total" : 1,
+  "totalPages" : 1,
   "totalElements" : 1,
   "last" : true,
-  "totalPages" : 1,
-  "sort" : null,
-  "first" : true,
-  "numberOfElements" : 1,
   "size" : 0,
-  "number" : 0
+  "number" : 0,
+  "sort" : null,
+  "numberOfElements" : 1,
+  "first" : true
 }</code></pre>
 </div>
 </div>
@@ -2036,7 +2036,7 @@ Content-Length: 55
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-05-21 18:21:50 CEST
+    Last updated 2016-11-25 17:33:45 CET
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.1/styles/github.min.css">

--- a/spring-auto-restdocs-example/generated-docs/index.html
+++ b/spring-auto-restdocs-example/generated-docs/index.html
@@ -439,7 +439,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#resources-items">2. Items</a>
 <ul class="sectlevel2">
 <li><a href="#resources-items-get">2.1. Get an item</a></li>
-<li><a href="#resources-items-all">2.2. Get all item</a></li>
+    <li><a href="#resources-items-all">2.2. Get all items</a></li>
 <li><a href="#resources-item-resource-test-add-item">2.3. Add Item</a></li>
 <li><a href="#resources-item-resource-test-update-item">2.4. Update Item</a></li>
 <li><a href="#resources-item-resource-test-delete-item">2.5. Delete Item</a></li>
@@ -632,8 +632,9 @@ switch directions, e.g. <code>?sort=firstname&amp;sort=lastname,asc</code>.</p><
 <td class="tableblock halign-left valign-top"><p class="tableblock">id</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">ID of the item.<br>
-Must be a valid ID.</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">ID of the item.
+    </p>
+        <p class="tableblock">Must be a valid ID.</p></td>
 </tr>
 </tbody>
 </table>
@@ -694,15 +695,17 @@ because the template returns "No data." instead of an empty table.</p>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.text</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.<br>
-Size must be between 2 and 20 inclusive.</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.
+    </p>
+        <p class="tableblock">Size must be between 2 and 20 inclusive.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.number</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.<br>
-Must be at least 1.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.
+    </p>
+        <p class="tableblock">Must be at least 1.<br>
 Must be at most 10.</p></td>
 </tr>
 <tr>
@@ -715,8 +718,9 @@ Must be at most 10.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.decimal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.<br>
-Must be at least 1.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.
+    </p>
+        <p class="tableblock">Must be at least 1.<br>
 Must be at most 10.</p></td>
 </tr>
 <tr>
@@ -729,8 +733,9 @@ Must be at most 10.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.enumType</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.<br>
-Must be one of [ONE, TWO].</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.
+    </p>
+        <p class="tableblock">Must be one of [ONE, TWO].</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">children</p></td>
@@ -791,7 +796,7 @@ Content-Length: 378
 </div>
 </div>
 <div class="sect2">
-<h3 id="resources-items-all"><a class="anchor" href="#resources-items-all"></a><a class="link" href="#resources-items-all">2.2. Get all item</a></h3>
+    <h3 id="resources-items-all"><a class="anchor" href="#resources-items-all"></a><a class="link" href="#resources-items-all">2.2. Get all items</a></h3>
 <div class="paragraph">
 <p><code>GET /items</code></p>
 </div>
@@ -859,15 +864,17 @@ Content-Length: 378
 <td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.text</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.<br>
-Size must be between 2 and 20 inclusive.</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.
+    </p>
+        <p class="tableblock">Size must be between 2 and 20 inclusive.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.number</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.<br>
-Must be at least 1.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.
+    </p>
+        <p class="tableblock">Must be at least 1.<br>
 Must be at most 10.</p></td>
 </tr>
 <tr>
@@ -880,8 +887,9 @@ Must be at most 10.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.decimal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.<br>
-Must be at least 1.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.
+    </p>
+        <p class="tableblock">Must be at least 1.<br>
 Must be at most 10.</p></td>
 </tr>
 <tr>
@@ -894,8 +902,9 @@ Must be at most 10.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.enumType</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.<br>
-Must be one of [ONE, TWO].</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.
+    </p>
+        <p class="tableblock">Must be one of [ONE, TWO].</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">[].children</p></td>
@@ -1012,8 +1021,9 @@ Content-Length: 483
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true<br>
 EN: false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.<br>
-DE: Size must be between 2 and 10 inclusive.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.
+    </p>
+        <p class="tableblock">DE: Size must be between 2 and 10 inclusive.<br>
 EN: Size must be between 4 and 12 inclusive.<br>
 Length must be between 0 and 20 inclusive.</p></td>
 </tr>
@@ -1021,8 +1031,9 @@ Length must be between 0 and 20 inclusive.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Country dependent type of the item.<br>
-DE: Must be one of [klein, groß].<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Country dependent type of the item.
+    </p>
+        <p class="tableblock">DE: Must be one of [klein, groß].<br>
 EN: Must be one of [small, big].<br>
 Size must be between 0 and 1000 inclusive.</p></td>
 </tr>
@@ -1041,7 +1052,7 @@ Size must be between 0 and 1000 inclusive.</p></td>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items' -i -X POST \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer d0936e63-7212-4335-810c-a185d30389ac' \
+    -H 'Authorization: Bearer 571c8c45-c99f-4438-8920-356e4b059365' \
     -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
@@ -1098,8 +1109,9 @@ Location: /items/2</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock">id</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Item ID.<br>
-Must be a valid ID.</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Item ID.
+    </p>
+        <p class="tableblock">Must be a valid ID.</p></td>
 </tr>
 </tbody>
 </table>
@@ -1133,8 +1145,9 @@ Must be a valid ID.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true<br>
 EN: false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.<br>
-DE: Size must be between 2 and 10 inclusive.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.
+    </p>
+        <p class="tableblock">DE: Size must be between 2 and 10 inclusive.<br>
 EN: Size must be between 4 and 12 inclusive.<br>
 Length must be between 0 and 20 inclusive.</p></td>
 </tr>
@@ -1142,8 +1155,9 @@ Length must be between 0 and 20 inclusive.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Country dependent type of the item.<br>
-DE: Must be one of [klein, groß].<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Country dependent type of the item.
+    </p>
+        <p class="tableblock">DE: Must be one of [klein, groß].<br>
 EN: Must be one of [small, big].<br>
 Size must be between 0 and 1000 inclusive.</p></td>
 </tr>
@@ -1196,15 +1210,17 @@ Size must be between 0 and 1000 inclusive.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.text</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.<br>
-Size must be between 2 and 20 inclusive.</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.
+    </p>
+        <p class="tableblock">Size must be between 2 and 20 inclusive.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.number</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.<br>
-Must be at least 1.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.
+    </p>
+        <p class="tableblock">Must be at least 1.<br>
 Must be at most 10.</p></td>
 </tr>
 <tr>
@@ -1217,8 +1233,9 @@ Must be at most 10.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.decimal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.<br>
-Must be at least 1.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.
+    </p>
+        <p class="tableblock">Must be at least 1.<br>
 Must be at most 10.</p></td>
 </tr>
 <tr>
@@ -1231,8 +1248,9 @@ Must be at most 10.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.enumType</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.<br>
-Must be one of [ONE, TWO].</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.
+    </p>
+        <p class="tableblock">Must be one of [ONE, TWO].</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">children</p></td>
@@ -1255,7 +1273,7 @@ Must be one of [ONE, TWO].</p></td>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X PUT \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer d0936e63-7212-4335-810c-a185d30389ac' \
+    -H 'Authorization: Bearer 571c8c45-c99f-4438-8920-356e4b059365' \
     -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
@@ -1291,9 +1309,10 @@ Content-Length: 90
 </div>
 <div class="paragraph">
 <p>Deletes item.<br>
-Item must exist.<br>
-<br>
-Non existing items are ignored</p>
+    Item must exist.</p>
+</div>
+    <div class="paragraph">
+        <p>Non existing items are ignored</p>
 </div>
 <div class="sect3">
 <h4 id="_authorization_5"><a class="anchor" href="#_authorization_5"></a><a class="link" href="#_authorization_5">2.5.1. Authorization</a></h4>
@@ -1323,8 +1342,9 @@ Non existing items are ignored</p>
 <td class="tableblock halign-left valign-top"><p class="tableblock">id</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">item ID.<br>
-Must be a valid ID.</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Item ID.
+    </p>
+        <p class="tableblock">Must be a valid ID.</p></td>
 </tr>
 </tbody>
 </table>
@@ -1352,7 +1372,7 @@ Must be a valid ID.</p></td>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X DELETE \
-    -H 'Authorization: Bearer d0936e63-7212-4335-810c-a185d30389ac'</code></pre>
+    -H 'Authorization: Bearer 571c8c45-c99f-4438-8920-356e4b059365'</code></pre>
 </div>
 </div>
 </div>
@@ -1407,15 +1427,17 @@ X-Frame-Options: DENY</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock">id</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Item ID.<br>
-Must be a valid ID.</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Item ID.
+    </p>
+        <p class="tableblock">Must be a valid ID.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">child</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Child ID.<br>
-DE: Must be at most 2.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Child ID.
+    </p>
+        <p class="tableblock">DE: Must be at most 2.<br>
 EN: Must be at least 1.</p></td>
 </tr>
 </tbody>
@@ -1479,15 +1501,17 @@ EN: Must be at least 1.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.text</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.<br>
-Size must be between 2 and 20 inclusive.</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.
+    </p>
+        <p class="tableblock">Size must be between 2 and 20 inclusive.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.number</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.<br>
-Must be at least 1.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.
+    </p>
+        <p class="tableblock">Must be at least 1.<br>
 Must be at most 10.</p></td>
 </tr>
 <tr>
@@ -1500,8 +1524,9 @@ Must be at most 10.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.decimal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.<br>
-Must be at least 1.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.
+    </p>
+        <p class="tableblock">Must be at least 1.<br>
 Must be at most 10.</p></td>
 </tr>
 <tr>
@@ -1514,8 +1539,9 @@ Must be at most 10.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.enumType</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.<br>
-Must be one of [ONE, TWO].</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.
+    </p>
+        <p class="tableblock">Must be one of [ONE, TWO].</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">children</p></td>
@@ -1606,15 +1632,17 @@ Content-Length: 99
 <td class="tableblock halign-left valign-top"><p class="tableblock">desc</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Lookup on description field.<br>
-Size must be between 0 and 255 inclusive.</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Lookup on description field.
+    </p>
+        <p class="tableblock">Size must be between 0 and 255 inclusive.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">hint</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Lookup hint.<br>
-Must be at least 10.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Lookup hint.
+    </p>
+        <p class="tableblock">Must be at least 10.<br>
 Must be at most 100.</p></td>
 </tr>
 </tbody>
@@ -1675,15 +1703,17 @@ Must be at most 100.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.text</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.<br>
-Size must be between 2 and 20 inclusive.</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.
+    </p>
+        <p class="tableblock">Size must be between 2 and 20 inclusive.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.number</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.<br>
-Must be at least 1.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.
+    </p>
+        <p class="tableblock">Must be at least 1.<br>
 Must be at most 10.</p></td>
 </tr>
 <tr>
@@ -1696,8 +1726,9 @@ Must be at most 10.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.decimal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.<br>
-Must be at least 1.<br>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.
+    </p>
+        <p class="tableblock">Must be at least 1.<br>
 Must be at most 10.</p></td>
 </tr>
 <tr>
@@ -1710,8 +1741,9 @@ Must be at most 10.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">attributes.enumType</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.<br>
-Must be one of [ONE, TWO].</p></td>
+    <td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.
+    </p>
+        <p class="tableblock">Must be one of [ONE, TWO].</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">children</p></td>
@@ -1774,8 +1806,8 @@ Content-Length: 625
   "pageable" : null,
   "total" : 1,
   "totalPages" : 1,
-  "totalElements" : 1,
   "last" : true,
+  "totalElements" : 1,
   "size" : 0,
   "number" : 0,
   "sort" : null,
@@ -1904,8 +1936,20 @@ Content-Length: 28
 </div>
 <div class="paragraph">
 <p>Executes a command on an item.<br>
-<br>
-This endpoint demos the basic support for @ModelAttribute. Note that the request body is documented as it would be JSON, but it is actually form-urlencoded. Setting the type manually can help to get the right documentation if the automatic document does not produce the right result.</p>
+    This endpoint demos the basic support for @ModelAttribute.</p>
+</div>
+    <div class="paragraph">
+        <p>Notes:</p>
+    </div>
+    <div class="ulist">
+        <ul>
+            <li>
+                <p>the request body is documented as it would be JSON, but it is actually form-urlencoded</p>
+            </li>
+            <li>
+                <p>setting the type manually can help to get the right documentation if the automatic document does not produce the right result.</p>
+            </li>
+        </ul>
 </div>
 <div class="sect3">
 <h4 id="_authorization_9"><a class="anchor" href="#_authorization_9"></a><a class="link" href="#_authorization_9">2.9.1. Authorization</a></h4>

--- a/spring-auto-restdocs-example/src/main/java/capital/scalable/restdocs/example/items/ItemUpdateRequest.java
+++ b/spring-auto-restdocs-example/src/main/java/capital/scalable/restdocs/example/items/ItemUpdateRequest.java
@@ -16,7 +16,6 @@
 
 package capital.scalable.restdocs.example.items;
 
-import javax.validation.constraints.Min;
 import javax.validation.constraints.Size;
 
 import capital.scalable.restdocs.example.constraints.OneOf;
@@ -49,10 +48,4 @@ class ItemUpdateRequest {
             @OneOf(value = {"small", "big"}, groups = English.class)
     })
     private String type;
-
-    /**
-     * Order of the item. If not specified it's 0.
-     */
-    @Min(100)
-    private int order;
 }

--- a/spring-auto-restdocs-example/src/main/java/capital/scalable/restdocs/example/items/ItemUpdateRequest.java
+++ b/spring-auto-restdocs-example/src/main/java/capital/scalable/restdocs/example/items/ItemUpdateRequest.java
@@ -16,6 +16,7 @@
 
 package capital.scalable.restdocs.example.items;
 
+import javax.validation.constraints.Min;
 import javax.validation.constraints.Size;
 
 import capital.scalable.restdocs.example.constraints.OneOf;
@@ -48,4 +49,10 @@ class ItemUpdateRequest {
             @OneOf(value = {"small", "big"}, groups = English.class)
     })
     private String type;
+
+    /**
+     * Order of the item. If not specified it's 0.
+     */
+    @Min(100)
+    private int order;
 }


### PR DESCRIPTION
fixes #114 
fixes #119

- **path params** as primitives are never optional are handled by spring, and whatever is configured in annotation (required=true/false), the param is always required otherwise spring complains about null-to-primitive assignment
- **request params** are optional only if defaultValue is supplied, otherwise not (even if required=false - spring behavior)
- **body fields as primitives** are by default optional and mandatory only if Jackson DeserializationConfig uses FAIL_ON_NULL_FOR_PRIMITIVES