### PR TITLE
Generic support for field/method tags in JSON

### DIFF
--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/javadoc/ClassJavadoc.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/javadoc/ClassJavadoc.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 class ClassJavadoc {
     private String comment;
-    private Map<String, String> fields = new HashMap<>();
+    private Map<String, FieldJavadoc> fields = new HashMap<>();
     private Map<String, MethodJavadoc> methods = new HashMap<>();
 
     public String getClassComment() {
@@ -31,23 +31,18 @@ class ClassJavadoc {
     }
 
     public String getFieldComment(String fieldName) {
-        return trimToEmpty(fields.get(fieldName));
-    }
-
-    public String getMethodComment(String methodName) {
-        MethodJavadoc methodJavadoc = methods.get(methodName);
-        if (methodJavadoc != null) {
-            return methodJavadoc.getComment();
+        FieldJavadoc fieldJavadoc = fields.get(fieldName);
+        if (fieldJavadoc != null) {
+            return trimToEmpty(fieldJavadoc.getComment());
         } else {
             return "";
         }
     }
 
-    public String getMethodTitle(String methodName) {
+    public String getMethodComment(String methodName) {
         MethodJavadoc methodJavadoc = methods.get(methodName);
-
         if (methodJavadoc != null) {
-            return methodJavadoc.getTitle();
+            return trimToEmpty(methodJavadoc.getComment());
         } else {
             return "";
         }
@@ -56,7 +51,25 @@ class ClassJavadoc {
     public String getMethodParameterComment(String methodName, String parameterName) {
         MethodJavadoc methodJavadoc = methods.get(methodName);
         if (methodJavadoc != null) {
-            return methodJavadoc.getParameterComment(parameterName);
+            return trimToEmpty(methodJavadoc.getParameterComment(parameterName));
+        } else {
+            return "";
+        }
+    }
+
+    public String getMethodTag(String javaMethodName, String tagName) {
+        MethodJavadoc methodJavadoc = methods.get(javaMethodName);
+        if (methodJavadoc != null) {
+            return trimToEmpty(methodJavadoc.getTag(tagName));
+        } else {
+            return "";
+        }
+    }
+
+    public String getFieldTag(String javaFieldName, String tagName) {
+        FieldJavadoc fieldJavadoc = fields.get(javaFieldName);
+        if (fieldJavadoc != null) {
+            return trimToEmpty(fieldJavadoc.getTag(tagName));
         } else {
             return "";
         }
@@ -67,20 +80,33 @@ class ClassJavadoc {
     }
 
     static class MethodJavadoc {
-        private String title;
         private String comment;
         private Map<String, String> parameters = new HashMap<>();
+        private Map<String, String> tags = new HashMap<>();
 
         public String getComment() {
-            return trimToEmpty(comment);
+            return comment;
         }
 
         public String getParameterComment(String parameterName) {
-            return trimToEmpty(parameters.get(parameterName));
+            return parameters.get(parameterName);
         }
 
-        public String getTitle() {
-            return trimToEmpty(title);
+        public String getTag(String tagName) {
+            return tags.get(tagName);
+        }
+    }
+
+    static class FieldJavadoc {
+        private String comment;
+        private Map<String, String> tags = new HashMap<>();
+
+        public String getComment() {
+            return comment;
+        }
+
+        public String getTag(String tagName) {
+            return tags.get(tagName);
         }
     }
 }

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/javadoc/JavadocReader.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/javadoc/JavadocReader.java
@@ -19,10 +19,12 @@ package capital.scalable.restdocs.javadoc;
 public interface JavadocReader {
     String resolveFieldComment(Class<?> javaBaseClass, String javaFieldName);
 
-    String resolveMethodComment(Class<?> javaBaseClass, String javaMethodName);
+    String resolveFieldTag(Class<?> javaBaseClass, String javaFieldName, String tagName);
 
-    String resolveMethodTitle(Class<?> javaBaseClass, String javaMethodName);
+    String resolveMethodComment(Class<?> javaBaseClass, String javaMethodName);
 
     String resolveMethodParameterComment(Class<?> javaBaseClass, String javaMethodName,
             String javaParameterName);
+
+    String resolveMethodTag(Class<?> javaBaseClass, String javaMethodName, String tagName);
 }

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/javadoc/JavadocReaderImpl.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/javadoc/JavadocReaderImpl.java
@@ -77,13 +77,13 @@ public class JavadocReaderImpl implements JavadocReader {
     }
 
     @Override
-    public String resolveMethodComment(Class<?> javaBaseClass, String javaMethodName) {
-        return classJavadoc(javaBaseClass).getMethodComment(javaMethodName);
+    public String resolveFieldTag(Class<?> javaBaseClass, String javaFieldName, String tagName) {
+        return classJavadoc(javaBaseClass).getFieldTag(javaFieldName, tagName);
     }
 
     @Override
-    public String resolveMethodTitle(Class<?> javaBaseClass, String javaMethodName) {
-        return classJavadoc(javaBaseClass).getMethodTitle(javaMethodName);
+    public String resolveMethodComment(Class<?> javaBaseClass, String javaMethodName) {
+        return classJavadoc(javaBaseClass).getMethodComment(javaMethodName);
     }
 
     @Override
@@ -91,6 +91,11 @@ public class JavadocReaderImpl implements JavadocReader {
             String javaParameterName) {
         return classJavadoc(javaBaseClass)
                 .getMethodParameterComment(javaMethodName, javaParameterName);
+    }
+
+    @Override
+    public String resolveMethodTag(Class<?> javaBaseClass, String javaMethodName, String tagName) {
+        return classJavadoc(javaBaseClass).getMethodTag(javaMethodName, tagName);
     }
 
     private ClassJavadoc classJavadoc(Class<?> clazz) {

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/section/SectionSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/section/SectionSnippet.java
@@ -113,8 +113,8 @@ public class SectionSnippet extends TemplatedSnippet {
     }
 
     private String resolveTitle(HandlerMethod handlerMethod, JavadocReader javadocReader) {
-        String title = javadocReader.resolveMethodTitle(handlerMethod.getBeanType(),
-                handlerMethod.getMethod().getName());
+        String title = javadocReader.resolveMethodTag(handlerMethod.getBeanType(),
+                handlerMethod.getMethod().getName(), "title");
         if (StringUtils.isBlank(title)) {
             title = createTitle(handlerMethod.getMethod().getName());
         }

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/javadoc/JavadocReaderImplIntegrationTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/javadoc/JavadocReaderImplIntegrationTest.java
@@ -30,14 +30,17 @@ public class JavadocReaderImplIntegrationTest {
         String comment = javadocReader.resolveFieldComment(IntegrationType.class, "usefulField");
         assertThat(comment, equalTo("Very useful field"));
 
+        comment = javadocReader.resolveFieldTag(IntegrationType.class, "usefulField", "see");
+        assertThat(comment, equalTo("other useful fields"));
+
         comment = javadocReader.resolveMethodComment(IntegrationType.class, "dummyMethod");
         // line breaks are not handled here - pure javadoc
         assertThat(comment, equalTo("Very useful method<br>\n with new line"));
 
-        comment = javadocReader.resolveMethodTitle(IntegrationType.class, "dummyMethod");
+        comment = javadocReader.resolveMethodTag(IntegrationType.class, "dummyMethod", "title");
         assertThat(comment, equalTo("My Dummy Method"));
 
-        comment = javadocReader.resolveMethodTitle(IntegrationType.class, "dummyMethod2");
+        comment = javadocReader.resolveMethodComment(IntegrationType.class, "dummyMethod2");
         assertThat(comment, equalTo(""));
 
         comment = javadocReader.resolveMethodParameterComment(IntegrationType.class, "dummyMethod",
@@ -52,6 +55,8 @@ public class JavadocReaderImplIntegrationTest {
     static class IntegrationType {
         /**
          * Very useful field
+         *
+         * @see other useful fields
          */
         private String usefulField;
 

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/javadoc/JavadocReaderImplTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/javadoc/JavadocReaderImplTest.java
@@ -53,6 +53,22 @@ public class JavadocReaderImplTest {
     }
 
     @Test
+    public void resolveFieldTag() {
+        JavadocReader javadocReader = JavadocReaderImpl.createWith(SOURCE_DIR);
+        String comment = javadocReader.resolveFieldTag(SimpleType.class, "simpleField",
+                "deprecated");
+        assertThat(comment, equalTo("Deprecation comment"));
+    }
+
+    @Test
+    public void resolveFieldTagFromClasspath() {
+        JavadocReader javadocReader = JavadocReaderImpl.createWith(null);
+        String comment = javadocReader.resolveFieldTag(SimpleType.class, "simpleField",
+                "deprecated");
+        assertThat(comment, equalTo("Deprecation comment from classpath"));
+    }
+
+    @Test
     public void resolveMethodComment() {
         JavadocReader javadocReader = JavadocReaderImpl.createWith(SOURCE_DIR);
         String comment = javadocReader.resolveMethodComment(SimpleType.class, "simpleMethod");
@@ -67,16 +83,16 @@ public class JavadocReaderImplTest {
     }
 
     @Test
-    public void resolveMethodTitle() {
+    public void resolveMethodTag() {
         JavadocReader javadocReader = JavadocReaderImpl.createWith(SOURCE_DIR);
-        String comment = javadocReader.resolveMethodTitle(SimpleType.class, "simpleMethod");
+        String comment = javadocReader.resolveMethodTag(SimpleType.class, "simpleMethod", "title");
         assertThat(comment, equalTo("Simple method title"));
     }
 
     @Test
-    public void resolveMethodTitleFromClasspath() {
+    public void resolveMethodTagFromClasspath() {
         JavadocReader javadocReader = JavadocReaderImpl.createWith(null);
-        String comment = javadocReader.resolveMethodTitle(SimpleType.class, "simpleMethod");
+        String comment = javadocReader.resolveMethodTag(SimpleType.class, "simpleMethod", "title");
         assertThat(comment, equalTo("Simple method title from classpath"));
     }
 
@@ -103,9 +119,15 @@ public class JavadocReaderImplTest {
         // json file for class does not exist
         String comment = javadocReader.resolveFieldComment(NotExisting.class, "simpleField2");
         assertThat(comment, is(""));
+        comment = javadocReader.resolveFieldTag(NotExisting.class, "simpleField", "tag");
+        assertThat(comment, is(""));
+        comment = javadocReader.resolveFieldTag(NotExisting.class, "simpleField2", "tag");
+        assertThat(comment, is(""));
         comment = javadocReader.resolveMethodComment(NotExisting.class, "simpleMethod");
         assertThat(comment, is(""));
-        comment = javadocReader.resolveMethodTitle(NotExisting.class, "simpleMethod");
+        comment = javadocReader.resolveMethodTag(NotExisting.class, "simpleMethod", "tag");
+        assertThat(comment, is(""));
+        comment = javadocReader.resolveMethodTag(NotExisting.class, "simpleMethod2", "tag");
         assertThat(comment, is(""));
         comment = javadocReader.resolveMethodParameterComment(NotExisting.class, "simpleMethod",
                 "simpleParameter");
@@ -119,9 +141,15 @@ public class JavadocReaderImplTest {
         // json file exists but field/method/parameter is not present
         String comment = javadocReader.resolveFieldComment(SimpleType.class, "simpleField2");
         assertThat(comment, is(""));
+        comment = javadocReader.resolveFieldTag(SimpleType.class, "simpleField", "tag");
+        assertThat(comment, is(""));
+        comment = javadocReader.resolveFieldTag(SimpleType.class, "simpleField2", "tag");
+        assertThat(comment, is(""));
         comment = javadocReader.resolveMethodComment(SimpleType.class, "simpleMethod2");
         assertThat(comment, is(""));
-        comment = javadocReader.resolveMethodTitle(SimpleType.class, "simpleMethod2");
+        comment = javadocReader.resolveMethodTag(SimpleType.class, "simpleMethod", "tag");
+        assertThat(comment, is(""));
+        comment = javadocReader.resolveMethodTag(SimpleType.class, "simpleMethod2", "tag");
         assertThat(comment, is(""));
         comment = javadocReader.resolveMethodParameterComment(SimpleType.class, "simpleMethod",
                 "simpleParameter2");

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/section/SectionSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/section/SectionSnippetTest.java
@@ -219,7 +219,7 @@ public class SectionSnippetTest extends AbstractSnippetTests {
 
 
     private void mockMethodTitle(Class<?> javaBaseClass, String methodName, String title) {
-        when(javadocReader.resolveMethodTitle(javaBaseClass, methodName))
+        when(javadocReader.resolveMethodTag(javaBaseClass, methodName, "title"))
                 .thenReturn(title);
     }
 

--- a/spring-auto-restdocs-core/src/test/resources/capital/scalable/restdocs/javadoc/JavadocReaderImplTest.SimpleType.json
+++ b/spring-auto-restdocs-core/src/test/resources/capital/scalable/restdocs/javadoc/JavadocReaderImplTest.SimpleType.json
@@ -1,13 +1,21 @@
 {
   "fields": {
-    "simpleField": "Simple field comment from classpath"
+    "simpleField": {
+      "comment": "Simple field comment from classpath",
+      "tags": {
+        "deprecated": "Deprecation comment from classpath"
+      }
+    }
   },
   "methods": {
     "simpleMethod": {
-      "title": "Simple method title from classpath",
       "comment": "Simple method comment from classpath",
       "parameters": {
         "simpleParameter": "Simple parameter comment from classpath"
+      },
+      "tags": {
+        "title": "Simple method title from classpath",
+        "deprecated": "Deprecation comment from classpath"
       }
     }
   }

--- a/spring-auto-restdocs-core/src/test/resources/json/capital/scalable/restdocs/javadoc/JavadocReaderImplTest.SimpleType.json
+++ b/spring-auto-restdocs-core/src/test/resources/json/capital/scalable/restdocs/javadoc/JavadocReaderImplTest.SimpleType.json
@@ -1,13 +1,21 @@
 {
   "fields": {
-    "simpleField": "Simple field comment"
+    "simpleField": {
+      "comment": "Simple field comment",
+      "tags": {
+        "deprecated": "Deprecation comment"
+      }
+    }
   },
   "methods": {
     "simpleMethod": {
-      "title": "Simple method title",
       "comment": "Simple method comment",
       "parameters": {
         "simpleParameter": "Simple parameter comment"
+      },
+      "tags": {
+        "title": "Simple method title",
+        "deprecated": "Deprecation comment"
       }
     }
   }

--- a/spring-auto-restdocs-json-doclet/src/main/java/capital/scalable/restdocs/jsondoclet/ClassDocumentation.java
+++ b/spring-auto-restdocs-json-doclet/src/main/java/capital/scalable/restdocs/jsondoclet/ClassDocumentation.java
@@ -25,7 +25,7 @@ import com.sun.javadoc.MethodDoc;
 
 public final class ClassDocumentation {
     private String comment = "";
-    private final Map<String, String> fields = new HashMap<>();
+    private final Map<String, FieldDocumentation> fields = new HashMap<>();
     private final Map<String, MethodDocumentation> methods = new HashMap<>();
 
     private ClassDocumentation() {
@@ -36,7 +36,7 @@ public final class ClassDocumentation {
         ClassDocumentation cd = new ClassDocumentation();
         cd.setComment(classDoc.commentText());
         for (FieldDoc fieldDoc : classDoc.fields(false)) {
-            cd.addField(fieldDoc.name(), fieldDoc.commentText());
+            cd.addField(fieldDoc);
         }
         for (MethodDoc methodDoc : classDoc.methods(false)) {
             cd.addMethod(methodDoc);
@@ -48,8 +48,8 @@ public final class ClassDocumentation {
         this.comment = comment;
     }
 
-    private void addField(String name, String comment) {
-        this.fields.put(name, comment);
+    private void addField(FieldDoc fieldDoc) {
+        this.fields.put(fieldDoc.name(), FieldDocumentation.fromFieldDoc(fieldDoc));
     }
 
     private void addMethod(MethodDoc methodDoc) {

--- a/spring-auto-restdocs-json-doclet/src/main/java/capital/scalable/restdocs/jsondoclet/DocletUtils.java
+++ b/spring-auto-restdocs-json-doclet/src/main/java/capital/scalable/restdocs/jsondoclet/DocletUtils.java
@@ -1,0 +1,11 @@
+package capital.scalable.restdocs.jsondoclet;
+
+public class DocletUtils {
+    private DocletUtils() {
+        // utils
+    }
+
+    public static String cleanupTagName(String name) {
+        return name.startsWith("@") ? name.substring(1) : name;
+    }
+}

--- a/spring-auto-restdocs-json-doclet/src/main/java/capital/scalable/restdocs/jsondoclet/FieldDocumentation.java
+++ b/spring-auto-restdocs-json-doclet/src/main/java/capital/scalable/restdocs/jsondoclet/FieldDocumentation.java
@@ -1,0 +1,27 @@
+package capital.scalable.restdocs.jsondoclet;
+
+import static capital.scalable.restdocs.jsondoclet.DocletUtils.cleanupTagName;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.sun.javadoc.FieldDoc;
+import com.sun.javadoc.Tag;
+
+public class FieldDocumentation {
+
+    private String comment;
+    private final Map<String, String> tags = new HashMap<>();
+
+    public static FieldDocumentation fromFieldDoc(FieldDoc fieldDoc) {
+        FieldDocumentation fd = new FieldDocumentation();
+        fd.comment = fieldDoc.commentText();
+
+        for (Tag tag : fieldDoc.tags()) {
+            fd.tags.put(cleanupTagName(tag.name()), tag.text());
+        }
+
+        return fd;
+    }
+
+}

--- a/spring-auto-restdocs-json-doclet/src/main/java/capital/scalable/restdocs/jsondoclet/MethodDocumentation.java
+++ b/spring-auto-restdocs-json-doclet/src/main/java/capital/scalable/restdocs/jsondoclet/MethodDocumentation.java
@@ -16,6 +16,8 @@
 
 package capital.scalable.restdocs.jsondoclet;
 
+import static capital.scalable.restdocs.jsondoclet.DocletUtils.cleanupTagName;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -24,9 +26,9 @@ import com.sun.javadoc.ParamTag;
 import com.sun.javadoc.Tag;
 
 public class MethodDocumentation {
-    private String title = "";
     private String comment = "";
     private final Map<String, String> parameters = new HashMap<>();
+    private final Map<String, String> tags = new HashMap<>();
 
     private MethodDocumentation() {
         // enforce usage of static factory method
@@ -36,12 +38,13 @@ public class MethodDocumentation {
         MethodDocumentation md = new MethodDocumentation();
         md.comment = methodDoc.commentText();
 
-        for (ParamTag param : methodDoc.paramTags()) {
-            md.parameters.put(param.parameterName(), param.parameterComment());
-        }
-        Tag[] title = methodDoc.tags("@title");
-        if (title.length > 0) {
-            md.title = title[0].text();
+        for (Tag tag : methodDoc.tags()) {
+            if (tag instanceof ParamTag) {
+                ParamTag paramTag = (ParamTag) tag;
+                md.parameters.put(paramTag.parameterName(), paramTag.parameterComment());
+            } else {
+                md.tags.put(cleanupTagName(tag.name()), tag.text());
+            }
         }
 
         return md;

--- a/spring-auto-restdocs-json-doclet/src/test/java/capital/scalable/restdocs/jsondoclet/DocumentedClass.java
+++ b/spring-auto-restdocs-json-doclet/src/test/java/capital/scalable/restdocs/jsondoclet/DocumentedClass.java
@@ -24,6 +24,8 @@ import java.math.BigDecimal;
 class DocumentedClass {
     /**
      * Location of resource
+     *
+     * @see path
      */
     public String location;
 
@@ -36,6 +38,8 @@ class DocumentedClass {
 
     /**
      * Executes request on specified location
+     *
+     * @title Execute request
      */
     public void execute() {
     }
@@ -46,6 +50,7 @@ class DocumentedClass {
      * @param when  when to initiate
      * @param force true if force
      * @title Do initiate
+     * @deprecated use other method
      */
     private void initiate(String when, boolean force, int notDocumented) {
     }

--- a/spring-auto-restdocs-json-doclet/src/test/resources/capital/scalable/restdocs/jsondoclet/DocumentedClass.json
+++ b/spring-auto-restdocs-json-doclet/src/test/resources/capital/scalable/restdocs/jsondoclet/DocumentedClass.json
@@ -1,26 +1,44 @@
 {
   "comment": "This is a test class. UTF 8 test: 我能吞下玻璃而不伤身体。Árvíztűrő tükörfúrógép",
   "fields": {
-    "path": "Path within location",
-    "location": "Location of resource",
-    "notDocumented": ""
+    "path": {
+      "comment": "Path within location",
+      "tags": {}
+    },
+    "location": {
+      "comment": "Location of resource",
+      "tags": {
+        "see": "path"
+      }
+    },
+    "notDocumented": {
+      "comment": "",
+      "tags": {}
+    }
   },
   "methods": {
     "initiate": {
-      "title": "Do initiate",
       "comment": "Initiates request",
       "parameters": {
         "force": "true if force",
         "when": "when to initiate"
+      },
+      "tags": {
+        "deprecated": "use other method",
+        "title": "Do initiate"
       }
     },
     "execute": {
       "comment": "Executes request on specified location",
-      "parameters": {}
+      "parameters": {},
+      "tags": {
+        "title": "Execute request"
+      }
     },
     "notDocumented": {
       "comment": "",
-      "parameters": {}
+      "parameters": {},
+      "tags": {}
     }
   }
 }


### PR DESCRIPTION
relates to #150
More generic json structure containing all javadoc tags, so we can then extract `@title`, `@deprecated` or whatever we want on demand.