### PR TITLE
Default value support for @RequestParam and @RequestHeader

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -946,16 +946,20 @@ public ItemResponse getItem(@PathVariable String id) { ... }</code></pre>
 <div class="sect2">
 <h3 id="snippets-request-parameters"><a class="link" href="#snippets-request-parameters">Request parameters snippet</a></h3>
 <div class="paragraph">
-<p><a href="https://github.com/ScaCap/spring-auto-restdocs/blob/master/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/RequestParametersSnippet.java">Request parameters snippet</a> automatically lists query parameters including their type, whether they are optional, and their Javadoc with constraints.</p>
+<p><a href="https://github.com/ScaCap/spring-auto-restdocs/blob/master/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/RequestParametersSnippet.java">Request parameters snippet</a> automatically lists query parameters including their type, whether they are optional, and their Javadoc with constraints. If a default value is set, it will also be included.</p>
 </div>
 <div class="listingblock">
 <div class="title">Code</div>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-java" data-lang="java">/**
  * @param descMatch Lookup on description field.
+ * @param lang Lookup on language.
  */
 @RequestMapping("search")
-public Page&lt;ItemResponse&gt; searchItem(@RequestParam("desc") String descMatch) { ... }</code></pre>
+public Page&lt;ItemResponse&gt; searchItem(
+ @RequestParam("desc") String descMatch,
+ @RequestParam(value= "language", required = false, defaultValue = "en") String lang
+ ) { ... }</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all spread">
@@ -981,13 +985,20 @@ public Page&lt;ItemResponse&gt; searchItem(@RequestParam("desc") String descMatc
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Lookup on description field.</p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">language</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Lookup on language.
+</p><p class="tableblock">Default value: "en".</p></td>
+</tr>
 </tbody>
 </table>
 </div>
 <div class="sect2">
 <h3 id="snippets-request-headers"><a class="link" href="#snippets-request-headers">Request headers snippet</a></h3>
 <div class="paragraph">
-<p><a href="https://github.com/ScaCap/spring-auto-restdocs/blob/master/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/RequestHeaderSnippet.java">Request headers snippet</a> automatically lists headers with their type, whether they are optional, and their Javadoc with constraints.</p>
+<p><a href="https://github.com/ScaCap/spring-auto-restdocs/blob/master/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/RequestHeaderSnippet.java">Request headers snippet</a> automatically lists headers with their type, whether they are optional, and their Javadoc with constraints. If a default value is set, it will also be included.</p>
 </div>
 <div class="listingblock">
 <div class="title">Code</div>
@@ -996,7 +1007,9 @@ public Page&lt;ItemResponse&gt; searchItem(@RequestParam("desc") String descMatc
  * @param lang Language we want the response in.
  */
 @RequestMapping("/all")
-public ItemResponse getItem(@RequestHeader("Accept-Language") String lang) { ... }</code></pre>
+public ItemResponse getItem(
+@RequestHeader(value = "Accept-Language", required = false, defaultValue = "en") String lang
+) { ... }</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all spread">
@@ -1019,8 +1032,9 @@ public ItemResponse getItem(@RequestHeader("Accept-Language") String lang) { ...
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Accept-Language</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Language we want the response in.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Language we want the response in.
+</p><p class="tableblock">Default value: "en".</p></td>
 </tr>
 </tbody>
 </table>
@@ -1736,7 +1750,7 @@ and has to be installed with the Maven command shown in the section above.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-11-04 09:58:35 GMT
+Last updated 2017-11-04 17:46:45 GMT
 </div>
 </div>
 <link rel="stylesheet" href="highlight/styles/github.min.css">

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/constraints/ConstraintReader.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/constraints/ConstraintReader.java
@@ -24,6 +24,7 @@ public interface ConstraintReader {
     String CONSTRAINTS_ATTRIBUTE = "constraints";
     String OPTIONAL_ATTRIBUTE = "optionals";
     String DEPRECATED_ATTRIBUTE = "deprecated";
+    String DEFAULT_VALUE_ATTRIBUTE = "default-value";
 
     List<String> getConstraintMessages(Class<?> javaBaseClass, String javaFieldName);
 

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/AbstractParameterSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/AbstractParameterSnippet.java
@@ -16,23 +16,6 @@
 
 package capital.scalable.restdocs.request;
 
-import static capital.scalable.restdocs.OperationAttributeHelper.getConstraintReader;
-import static capital.scalable.restdocs.OperationAttributeHelper.getHandlerMethod;
-import static capital.scalable.restdocs.OperationAttributeHelper.getJavadocReader;
-import static capital.scalable.restdocs.constraints.ConstraintReader.CONSTRAINTS_ATTRIBUTE;
-import static capital.scalable.restdocs.constraints.ConstraintReader.DEPRECATED_ATTRIBUTE;
-import static capital.scalable.restdocs.constraints.ConstraintReader.OPTIONAL_ATTRIBUTE;
-import static capital.scalable.restdocs.util.FieldDescriptorUtil.assertAllDocumented;
-import static capital.scalable.restdocs.util.TypeUtil.determineTypeName;
-import static java.util.Collections.singletonList;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.util.StringUtils.hasLength;
-
-import java.lang.annotation.Annotation;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import capital.scalable.restdocs.constraints.ConstraintReader;
 import capital.scalable.restdocs.javadoc.JavadocReader;
 import capital.scalable.restdocs.section.SectionSupport;
@@ -41,7 +24,26 @@ import org.springframework.core.MethodParameter;
 import org.springframework.restdocs.operation.Operation;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.snippet.Attributes.Attribute;
+import org.springframework.web.bind.annotation.ValueConstants;
 import org.springframework.web.method.HandlerMethod;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static capital.scalable.restdocs.OperationAttributeHelper.getConstraintReader;
+import static capital.scalable.restdocs.OperationAttributeHelper.getHandlerMethod;
+import static capital.scalable.restdocs.OperationAttributeHelper.getJavadocReader;
+import static capital.scalable.restdocs.constraints.ConstraintReader.CONSTRAINTS_ATTRIBUTE;
+import static capital.scalable.restdocs.constraints.ConstraintReader.DEFAULT_VALUE_ATTRIBUTE;
+import static capital.scalable.restdocs.constraints.ConstraintReader.DEPRECATED_ATTRIBUTE;
+import static capital.scalable.restdocs.constraints.ConstraintReader.OPTIONAL_ATTRIBUTE;
+import static capital.scalable.restdocs.util.FieldDescriptorUtil.assertAllDocumented;
+import static capital.scalable.restdocs.util.TypeUtil.determineTypeName;
+import static java.util.Collections.singletonList;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.util.StringUtils.hasLength;
 
 abstract class AbstractParameterSnippet<A extends Annotation> extends StandardTableSnippet
         implements SectionSupport {
@@ -90,9 +92,20 @@ abstract class AbstractParameterSnippet<A extends Annotation> extends StandardTa
         Attribute constraints = constraintAttribute(param, constraintReader);
         Attribute optionals = optionalsAttribute(param, annot);
         Attribute deprecated = deprecatedAttribute(param, annot, javadocReader);
-        descriptor.attributes(constraints, optionals, deprecated);
+        final Attribute defaultValue = defaultValueAttribute(annot);
+        if (defaultValue == null) {
+            descriptor.attributes(constraints, optionals, deprecated);
+        } else {
+            descriptor.attributes(constraints, optionals, deprecated, defaultValue);
+        }
 
         fieldDescriptors.add(descriptor);
+    }
+
+    abstract protected String getDefaultValue(A annotation);
+
+    protected boolean isCustomDefaultValue(final String defaultValue) {
+        return defaultValue != null && !ValueConstants.DEFAULT_NONE.equals(defaultValue);
     }
 
     protected Attribute constraintAttribute(MethodParameter param,
@@ -108,6 +121,12 @@ abstract class AbstractParameterSnippet<A extends Annotation> extends StandardTa
             JavadocReader javadocReader) {
         return new Attribute(DEPRECATED_ATTRIBUTE,
                 param.getParameterAnnotation(Deprecated.class) != null ? "" : null);
+    }
+
+    protected Attribute defaultValueAttribute(A annot) {
+        final String defaultValue = getDefaultValue(annot);
+
+        return isCustomDefaultValue(defaultValue) ? new Attribute(DEFAULT_VALUE_ATTRIBUTE, defaultValue) : null;
     }
 
     protected abstract boolean isRequired(MethodParameter param, A annot);

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/PathParametersSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/PathParametersSnippet.java
@@ -62,4 +62,11 @@ public class PathParametersSnippet extends AbstractParameterSnippet<PathVariable
     protected boolean shouldFailOnUndocumentedParams() {
         return failOnUndocumentedParams;
     }
+
+    @Override
+    protected String getDefaultValue(final PathVariable annotation)
+    {
+        // @PathVariable does not have a default value
+        return null;
+    }
 }

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/RequestHeaderSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/RequestHeaderSnippet.java
@@ -62,4 +62,10 @@ public class RequestHeaderSnippet extends AbstractParameterSnippet<RequestHeader
     protected boolean shouldFailOnUndocumentedParams() {
         return failOnUndocumentedParams;
     }
+
+    @Override
+    protected String getDefaultValue(final RequestHeader annotation)
+    {
+        return annotation.defaultValue();
+    }
 }

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/RequestParametersSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/RequestParametersSnippet.java
@@ -93,4 +93,10 @@ public class RequestParametersSnippet extends AbstractParameterSnippet<RequestPa
     protected boolean shouldFailOnUndocumentedParams() {
         return failOnUndocumentedParams;
     }
+
+    @Override
+    protected String getDefaultValue(final RequestParam annotation)
+    {
+        return annotation.defaultValue();
+    }
 }

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/snippet/StandardTableSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/snippet/StandardTableSnippet.java
@@ -19,6 +19,7 @@ package capital.scalable.restdocs.snippet;
 import static capital.scalable.restdocs.OperationAttributeHelper.determineTemplateFormatting;
 import static capital.scalable.restdocs.OperationAttributeHelper.getHandlerMethod;
 import static capital.scalable.restdocs.constraints.ConstraintReader.CONSTRAINTS_ATTRIBUTE;
+import static capital.scalable.restdocs.constraints.ConstraintReader.DEFAULT_VALUE_ATTRIBUTE;
 import static capital.scalable.restdocs.constraints.ConstraintReader.DEPRECATED_ATTRIBUTE;
 import static capital.scalable.restdocs.constraints.ConstraintReader.OPTIONAL_ATTRIBUTE;
 import static capital.scalable.restdocs.javadoc.JavadocUtil.convertFromJavadoc;
@@ -35,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 
 import capital.scalable.restdocs.util.TemplateFormatting;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.restdocs.operation.Operation;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.snippet.TemplatedSnippet;
@@ -102,7 +104,8 @@ public abstract class StandardTableSnippet extends TemplatedSnippet {
 
         String optional = resolveOptional(descriptor, templateFormatting);
         List<String> constraints = resolveConstraints(descriptor);
-        description = joinAndFormat(description, constraints, templateFormatting);
+        final String defaultValue = resolveDefaultValue(descriptor);
+        description = joinAndFormat(description, constraints, defaultValue, templateFormatting);
 
         Map<String, Object> model = new HashMap<>();
         model.put("path", path);
@@ -110,6 +113,12 @@ public abstract class StandardTableSnippet extends TemplatedSnippet {
         model.put("optional", optional);
         model.put("description", description);
         return model;
+    }
+
+    private String defaultValuePrefix(final String description)
+    {
+        // if we have no description, we don't want to add new lines
+        return StringUtils.isEmpty(description) ? StringUtils.EMPTY : "\n\n";
     }
 
     private List<String> resolveConstraints(FieldDescriptor descriptor) {
@@ -137,6 +146,15 @@ public abstract class StandardTableSnippet extends TemplatedSnippet {
         }
     }
 
+    private String resolveDefaultValue(FieldDescriptor descriptor) {
+        Object defaultValue = descriptor.getAttributes().get(DEFAULT_VALUE_ATTRIBUTE);
+        if (defaultValue != null) {
+            return "Default value: \"" + toString(defaultValue) + "\".";
+        } else {
+            return "";
+        }
+    }
+
     private String toString(Object value) {
         if (value != null) {
             return trimToEmpty(value.toString());
@@ -146,7 +164,7 @@ public abstract class StandardTableSnippet extends TemplatedSnippet {
     }
 
     private String joinAndFormat(String description, List<String> constraints,
-            TemplateFormatting templateFormatting) {
+                                 final String defaultValue, TemplateFormatting templateFormatting) {
         StringBuilder res = new StringBuilder(description);
         if (!description.isEmpty() && !description.endsWith(".")) {
             res.append('.');
@@ -158,6 +176,9 @@ public abstract class StandardTableSnippet extends TemplatedSnippet {
         }
 
         res.append(constr.toString());
+        if (StringUtils.isNotEmpty(defaultValue)) {
+            res.append(defaultValuePrefix(description)).append(defaultValue);
+        }
 
         return res.toString().replace("|", "\\|");
     }

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/RequestParametersSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/RequestParametersSnippetTest.java
@@ -88,7 +88,28 @@ public class RequestParametersSnippetTest extends AbstractSnippetTests {
                 tableWithHeader("Parameter", "Type", "Optional", "Description")
                         .row("param1", "Decimal", "false", "A decimal.")
                         .row("param2", "Boolean", "false", "A boolean.")
-                        .row("param3", "Integer", "true", "An integer."));
+                        .row("param3", "Integer", "true", "An integer.\n\nDefault value: \"1\"."));
+
+        new RequestParametersSnippet().document(operationBuilder
+                .attribute(HandlerMethod.class.getName(), handlerMethod)
+                .attribute(JavadocReader.class.getName(), javadocReader)
+                .attribute(ConstraintReader.class.getName(), constraintReader)
+                .build());
+    }
+
+    @Test
+    public void simpleRequestWithPrimitivesDefaultValueParameterNotDocumented() throws Exception {
+        HandlerMethod handlerMethod = createHandlerMethod("searchItem2", double.class,
+                boolean.class, int.class);
+        initParameters(handlerMethod);
+        mockParamComment("searchItem2", "param1", "A decimal");
+        mockParamComment("searchItem2", "param2", "A boolean");
+
+        this.snippets.expect(REQUEST_PARAMETERS).withContents(
+                tableWithHeader("Parameter", "Type", "Optional", "Description")
+                        .row("param1", "Decimal", "false", "A decimal.")
+                        .row("param2", "Boolean", "false", "A boolean.")
+                        .row("param3", "Integer", "true", "Default value: \"1\"."));
 
         new RequestParametersSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)

--- a/spring-auto-restdocs-docs/snippets.adoc
+++ b/spring-auto-restdocs-docs/snippets.adoc
@@ -114,16 +114,20 @@ public ItemResponse getItem(@PathVariable String id) { ... }
 [[snippets-request-parameters]]
 === Request parameters snippet
 
-link:{core-package}/request/RequestParametersSnippet.java[Request parameters snippet] automatically lists query parameters including their type, whether they are optional, and their Javadoc with constraints.
+link:{core-package}/request/RequestParametersSnippet.java[Request parameters snippet] automatically lists query parameters including their type, whether they are optional, and their Javadoc with constraints. If a default value is set, it will also be included.
 
 .Code
 [source,java]
 ----
 /**
  * @param descMatch Lookup on description field.
+ * @param lang Lookup on language.
  */
 @RequestMapping("search")
-public Page<ItemResponse> searchItem(@RequestParam("desc") String descMatch) { ... }
+public Page<ItemResponse> searchItem(
+ @RequestParam("desc") String descMatch,
+ @RequestParam(value= "language", required = false, defaultValue = "en") String lang
+ ) { ... }
 ----
 
 .Result
@@ -135,12 +139,19 @@ public Page<ItemResponse> searchItem(@RequestParam("desc") String descMatch) { .
 | false
 | Lookup on description field.
 
+| language
+| String
+| true
+| Lookup on language.
+
+Default value: "en".
+
 |===
 
 [[snippets-request-headers]]
 === Request headers snippet
 
-link:{core-package}/request/RequestHeaderSnippet.java[Request headers snippet] automatically lists headers with their type, whether they are optional, and their Javadoc with constraints.
+link:{core-package}/request/RequestHeaderSnippet.java[Request headers snippet] automatically lists headers with their type, whether they are optional, and their Javadoc with constraints. If a default value is set, it will also be included.
 
 .Code
 [source,java]
@@ -149,7 +160,9 @@ link:{core-package}/request/RequestHeaderSnippet.java[Request headers snippet] a
  * @param lang Language we want the response in.
  */
 @RequestMapping("/all")
-public ItemResponse getItem(@RequestHeader("Accept-Language") String lang) { ... }
+public ItemResponse getItem(
+@RequestHeader(value = "Accept-Language", required = false, defaultValue = "en") String lang
+) { ... }
 ----
 
 .Result
@@ -158,8 +171,10 @@ public ItemResponse getItem(@RequestHeader("Accept-Language") String lang) { ...
 
 | Accept-Language
 | String
-| false
+| true
 | Language we want the response in.
+
+Default value: "en".
 
 |===
 

--- a/spring-auto-restdocs-example/generated-docs/index.html
+++ b/spring-auto-restdocs-example/generated-docs/index.html
@@ -1117,7 +1117,7 @@ Size must be between 0 and 1000 inclusive.</p></td>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items' -i -X POST \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer 833e0aa2-bb14-4647-bdba-fe9dc4c8285f' \
+    -H 'Authorization: Bearer 024eccb9-bbe3-448f-b6ea-804db7e3f1c0' \
     -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
@@ -1352,7 +1352,7 @@ Must be at most 10.</p></td>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X PUT \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer 833e0aa2-bb14-4647-bdba-fe9dc4c8285f' \
+    -H 'Authorization: Bearer 024eccb9-bbe3-448f-b6ea-804db7e3f1c0' \
     -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
@@ -1455,7 +1455,7 @@ Item must exist.</p>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X DELETE \
-    -H 'Authorization: Bearer 833e0aa2-bb14-4647-bdba-fe9dc4c8285f'</code></pre>
+    -H 'Authorization: Bearer 024eccb9-bbe3-448f-b6ea-804db7e3f1c0'</code></pre>
 </div>
 </div>
 </div>
@@ -1935,12 +1935,12 @@ Content-Length: 830
     "offset" : 0
   },
   "total" : 1,
-  "totalPages" : 1,
   "totalElements" : 1,
   "last" : true,
+  "totalPages" : 1,
   "sort" : null,
-  "numberOfElements" : 1,
   "first" : true,
+  "numberOfElements" : 1,
   "size" : 20,
   "number" : 0
 }</code></pre>


### PR DESCRIPTION
As suggested by @fbenz,  if a default value is set in `@RequestParam` or `@RequestHeader` annotation, a new line with its value is now added to the parameter description.