### PR TITLE
defaultValue for @RequestParam implies required=false

### DIFF
--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/RequestParametersSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/RequestParametersSnippet.java
@@ -46,9 +46,20 @@ public class RequestParametersSnippet extends AbstractParameterSnippet<RequestPa
 
     @Override
     protected boolean isRequired(MethodParameter param, RequestParam annot) {
-        return param.getParameterType().isPrimitive()
-                ? ValueConstants.DEFAULT_NONE.equals(annot.defaultValue())
-                : annot.required();
+        if (param.getParameterType().isPrimitive()) {
+            // a primitive type is required if no defaultValue is set
+            return !hasDefaultValue(annot);
+        } else {
+            if (hasDefaultValue(annot)) {
+                // Having a defaultValue set implies required=false
+                return false;
+            }
+            return annot.required();
+        }
+    }
+
+    private boolean hasDefaultValue(RequestParam annot) {
+        return !ValueConstants.DEFAULT_NONE.equals(annot.defaultValue());
     }
 
     @Override

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/RequestParametersSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/RequestParametersSnippet.java
@@ -46,19 +46,18 @@ public class RequestParametersSnippet extends AbstractParameterSnippet<RequestPa
 
     @Override
     protected boolean isRequired(MethodParameter param, RequestParam annot) {
-        if (param.getParameterType().isPrimitive()) {
-            // a primitive type is required if no defaultValue is set
-            return !hasDefaultValue(annot);
+        if (hasDefaultValue(annot)) {
+            // Having a defaultValue set implies required=false
+            return false;
+        } else if (param.getParameterType().isPrimitive()) {
+            // A primitive type is required if no defaultValue is set, regardless of the value of the required flag
+            return true;
         } else {
-            if (hasDefaultValue(annot)) {
-                // Having a defaultValue set implies required=false
-                return false;
-            }
             return annot.required();
         }
     }
 
-    private boolean hasDefaultValue(RequestParam annot) {
+    private static boolean hasDefaultValue(RequestParam annot) {
         return !ValueConstants.DEFAULT_NONE.equals(annot.defaultValue());
     }
 

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/RequestParametersSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/RequestParametersSnippetTest.java
@@ -119,6 +119,27 @@ public class RequestParametersSnippetTest extends AbstractSnippetTests {
     }
 
     @Test
+    public void simpleRequestWithStringDefaultValueParameter() throws Exception {
+        HandlerMethod handlerMethod = createHandlerMethod("searchItem2String", double.class,
+                boolean.class, String.class);
+        initParameters(handlerMethod);
+        mockParamComment("searchItem2String", "param1", "A decimal");
+        mockParamComment("searchItem2String", "param2", "A boolean");
+        mockParamComment("searchItem2String", "param3", "A String");
+
+        this.snippets.expect(REQUEST_PARAMETERS).withContents(
+                tableWithHeader("Parameter", "Type", "Optional", "Description")
+                        .row("param1", "Decimal", "false", "A decimal.")
+                        .row("param2", "Boolean", "false", "A boolean.")
+                        .row("param3", "String", "true", "A String.\n\nDefault value: \"de\"."));
+
+        new RequestParametersSnippet().document(operationBuilder
+                .attribute(HandlerMethod.class.getName(), handlerMethod)
+                .attribute(JavadocReader.class.getName(), javadocReader)
+                .attribute(ConstraintReader.class.getName(), constraintReader)
+                .build());
+    }
+    @Test
     public void noParameters() throws Exception {
         HandlerMethod handlerMethod = createHandlerMethod("items");
 
@@ -236,6 +257,12 @@ public class RequestParametersSnippetTest extends AbstractSnippetTests {
         public void searchItem2(@RequestParam double param1,    // required
                 @RequestParam(required = false) boolean param2, // required anyway
                 @RequestParam(defaultValue = "1") int param3) { // not required
+            // NOOP
+        }
+
+        public void searchItem2String(@RequestParam double param1,    // required
+                                @RequestParam(required = false) boolean param2, // required anyway
+                                @RequestParam(defaultValue = "de") String param3) { // not required
             // NOOP
         }
 


### PR DESCRIPTION
This was not handled correctly for non primitive types annotated
with @RequestParam.