### PR TITLE
Support for Bean Validation 2.0

### DIFF
--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/constraints/SkippableConstraintResolver.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/constraints/SkippableConstraintResolver.java
@@ -29,8 +29,10 @@ import org.springframework.restdocs.constraints.Constraint;
 class SkippableConstraintResolver implements MethodParameterConstraintResolver {
     public static final Collection<String> MANDATORY_VALUE_ANNOTATIONS = Arrays.asList(
             "javax.validation.constraints.NotNull",
-            "org.hibernate.validator.constraints.NotBlank",
-            "org.hibernate.validator.constraints.NotEmpty");
+            "javax.validation.constraints.NotBlank", // since Bean Validation 2.0
+            "javax.validation.constraints.NotEmpty", // since Bean Validation 2.0
+            "org.hibernate.validator.constraints.NotBlank",  // Hibernate Validator before 6.0
+            "org.hibernate.validator.constraints.NotEmpty"); // Hibernate Validator before 6.0
 
     private final MethodParameterConstraintResolver delegate;
     private final GroupDescriptionResolver descriptionResolver;


### PR DESCRIPTION
Changes between Bean Validation 1.1 and 2.0: http://beanvalidation.org/2.0/

This PR is small because we only derive the optional flag from the constraints and do not maintain any descriptions. Descriptions are provided by Spring REST Docs.

Spring REST Docs added support in version 2.0, see https://github.com/spring-projects/spring-restdocs/issues/454 Users of an older version of Spring REST Docs have to add the constraint descriptions to their projects - just like with custom constraints, see https://scacap.github.io/spring-auto-restdocs/#constraints-custom

I didn't adjust any test, because the default Bean Validation version for this project is still 1.1.

Fixes #174 