### PR TITLE
Fix Maven badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Spring Auto REST Docs
 [![Apache License 2](https://img.shields.io/badge/license-ASF2-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0.txt)
 [![Build Status](https://travis-ci.org/ScaCap/spring-auto-restdocs.svg?branch=master)](https://travis-ci.org/ScaCap/spring-auto-restdocs)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/capital.scalable/spring-auto-restdocs-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/capital.scalable/spring-auto-restdocs-core/)
+[![Maven Central status](https://img.shields.io/maven-central/v/capital.scalable/spring-auto-restdocs-core.svg)](https://search.maven.org/#search%7Cga%7C1%7Ccapital.scalable%20spring-auto-restdocs)
 
 The aim of this [Spring REST Docs](https://projects.spring.io/spring-restdocs/)
 extension is to help you write even less - both code and documentation.


### PR DESCRIPTION
`maven-badges.herokuapp.com` is down and thus the Maven badge is broken at the moment. `shields.io` offers the same badge.