### PR TITLE
Deprecated fix

### DIFF
--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/FieldDocumentationVisitorContext.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/FieldDocumentationVisitorContext.java
@@ -181,29 +181,34 @@ class FieldDocumentationVisitorContext {
         }
     }
 
-    private String resolveComment(Class<?> javaBaseClass, String javaFieldName) {
-        String comment = javadocReader.resolveFieldComment(javaBaseClass, javaFieldName);
+    private String resolveComment(Class<?> javaBaseClass, String javaFieldOrMethodName) {
+        // prefer method comments first
+        String comment = javadocReader.resolveMethodComment(javaBaseClass, javaFieldOrMethodName);
         if (isBlank(comment)) {
-            // fallback if fieldName is getter method and comment is on the method itself
-            comment = javadocReader.resolveMethodComment(javaBaseClass, javaFieldName);
+            // fallback to field
+            comment = javadocReader.resolveFieldComment(javaBaseClass, javaFieldOrMethodName);
         }
-        if (isBlank(comment) && isGetter(javaFieldName)) {
-            // fallback if fieldName is getter method but comment is on field itself
-            comment = javadocReader.resolveFieldComment(javaBaseClass, fromGetter(javaFieldName));
+        if (isBlank(comment) && isGetter(javaFieldOrMethodName)) {
+            // fallback if name is getter method but comment is on field itself
+            comment = javadocReader.resolveFieldComment(javaBaseClass,
+                    fromGetter(javaFieldOrMethodName));
         }
         return comment;
     }
 
-    private String resolveTag(Class<?> javaBaseClass, String javaFieldName, String tagName) {
-        String comment = javadocReader.resolveFieldTag(javaBaseClass, javaFieldName, tagName);
+    private String resolveTag(Class<?> javaBaseClass, String javaFieldOrMethodName,
+            String tagName) {
+        // prefer method comments first
+        String comment = javadocReader.resolveMethodTag(javaBaseClass, javaFieldOrMethodName,
+                tagName);
         if (isBlank(comment)) {
-            // fallback if fieldName is getter method and comment is on the method itself
-            comment = javadocReader.resolveMethodTag(javaBaseClass, javaFieldName, tagName);
+            // fallback to field
+            comment = javadocReader.resolveFieldTag(javaBaseClass, javaFieldOrMethodName, tagName);
         }
-        if (isBlank(comment) && isGetter(javaFieldName)) {
-            // fallback if fieldName is getter method but comment is on field itself
-            comment = javadocReader.resolveFieldTag(javaBaseClass, fromGetter(javaFieldName),
-                    tagName);
+        if (isBlank(comment) && isGetter(javaFieldOrMethodName)) {
+            // fallback if name is getter method but comment is on field itself
+            comment = javadocReader.resolveFieldTag(javaBaseClass,
+                    fromGetter(javaFieldOrMethodName), tagName);
         }
         return comment;
     }

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/FieldDocumentationVisitorContext.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/FieldDocumentationVisitorContext.java
@@ -28,13 +28,13 @@ import static capital.scalable.restdocs.util.FieldUtil.isGetter;
 import static capital.scalable.restdocs.util.FormatUtil.addDot;
 import static capital.scalable.restdocs.util.FormatUtil.join;
 import static capital.scalable.restdocs.util.TypeUtil.isPrimitive;
+import static capital.scalable.restdocs.util.TypeUtil.resolveAnnotation;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -45,7 +45,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import org.slf4j.Logger;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.snippet.Attributes.Attribute;
-import org.springframework.util.ReflectionUtils;
 
 class FieldDocumentationVisitorContext {
     private static final Logger log = getLogger(FieldDocumentationVisitorContext.class);
@@ -163,9 +162,9 @@ class FieldDocumentationVisitorContext {
     }
 
     private String resolveDeprecatedMessage(Class<?> javaBaseClass, String javaFieldName) {
-        Field field = ReflectionUtils.findField(javaBaseClass, javaFieldName);
-        boolean isDeprecated = field != null && field.getAnnotation(Deprecated.class) != null;
-        String comment = javadocReader.resolveFieldTag(javaBaseClass, javaFieldName, "deprecated");
+        boolean isDeprecated =
+                resolveAnnotation(javaBaseClass, javaFieldName, Deprecated.class) != null;
+        String comment = resolveTag(javaBaseClass, javaFieldName, "deprecated");
         if (isDeprecated || isNotBlank(comment)) {
             return trimToEmpty(comment);
         } else {

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/util/TypeUtil.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/util/TypeUtil.java
@@ -24,7 +24,9 @@ import static capital.scalable.restdocs.util.FieldUtil.isGetter;
 import static org.apache.commons.lang3.ClassUtils.primitiveToWrapper;
 import static org.apache.commons.lang3.StringUtils.chop;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -98,11 +100,33 @@ public class TypeUtil {
     }
 
     public static boolean isPrimitive(Class<?> javaBaseClass, String javaFieldName) {
+        Field field = findField(javaBaseClass, javaFieldName);
+        return field != null && field.getType().isPrimitive();
+    }
+
+    public static Field findField(Class<?> javaBaseClass, String javaFieldName) {
         Field field = ReflectionUtils.findField(javaBaseClass, javaFieldName);
         if (field == null && isGetter(javaFieldName)) {
             field = ReflectionUtils.findField(javaBaseClass, fromGetter(javaFieldName));
         }
-        return field != null && field.getType().isPrimitive();
+        return field;
+    }
+
+    public static Method findMethod(Class<?> javaBaseClass, String javaMethodName) {
+        return ReflectionUtils.findMethod(javaBaseClass, javaMethodName);
+    }
+
+    public static <T extends Annotation> T resolveAnnotation(Class<?> javaBaseClass,
+            String javaFieldName, Class<T> annotationClass) {
+        Field field = findField(javaBaseClass, javaFieldName);
+        if (field != null) {
+            return field.getAnnotation(annotationClass);
+        }
+        Method method = findMethod(javaBaseClass, javaFieldName);
+        if (method != null) {
+            return method.getAnnotation(annotationClass);
+        }
+        return null;
     }
 
     public static List<JavaType> resolveAllTypes(JavaType javaType, TypeFactory typeFactory) {

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippetTest.java
@@ -270,9 +270,11 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
         HandlerMethod handlerMethod = createHandlerMethod("removeItem");
         mockFieldComment(DeprecatedItem.class, "index", "item's index");
         mockFieldComment(DeprecatedItem.class, "index2", "item's index2");
-        mockMethodComment(DeprecatedItem.class, "getIndex3", "item's index3");
-        mockMethodComment(DeprecatedItem.class, "getIndex4", "item's index4");
-        // index and getIndex3 have annotations
+        mockFieldComment(DeprecatedItem.class, "index3", "item's index3");
+        mockFieldComment(DeprecatedItem.class, "index4", "item's index4");
+        mockFieldComment(DeprecatedItem.class, "index5", "item's index5");
+        mockMethodComment(DeprecatedItem.class, "getIndex6", "item's index6");
+
         // index2 and getIndex4 have @deprecated Javadoc
         mockDeprecatedField(DeprecatedItem.class, "index2", "use something else");
         mockDeprecatedMethod(DeprecatedItem.class, "getIndex4", "use something else");
@@ -286,7 +288,35 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
                         .row("index3", "Integer", "true",
                                 "**Deprecated.**\n\nItem's index3.")
                         .row("index4", "Integer", "true",
-                                "**Deprecated.** Use something else.\n\nItem's index4."));
+                                "**Deprecated.** Use something else.\n\nItem's index4.")
+                        .row("index5", "Integer", "true",
+                                "**Deprecated.**\n\nItem's index5.")
+                        .row("index6", "Integer", "true",
+                                "**Deprecated.**\n\nItem's index6."));
+
+        new JacksonResponseFieldSnippet().document(operationBuilder
+                .attribute(HandlerMethod.class.getName(), handlerMethod)
+                .attribute(ObjectMapper.class.getName(), mapper)
+                .attribute(JavadocReader.class.getName(), javadocReader)
+                .attribute(ConstraintReader.class.getName(), constraintReader)
+                .build());
+    }
+
+    @Test
+    public void comment() throws Exception {
+        HandlerMethod handlerMethod = createHandlerMethod("commentItem");
+        mockFieldComment(CommentedItem.class, "field", "field");
+        mockFieldComment(CommentedItem.class, "field2", "field 2");
+        mockFieldComment(CommentedItem.class, "field3", "field 3");
+        mockMethodComment(CommentedItem.class, "getField3", "method 3"); // preferred
+        mockMethodComment(CommentedItem.class, "getField4", "method 4");
+
+        this.snippets.expect(RESPONSE_FIELDS).withContents(
+                tableWithHeader("Path", "Type", "Optional", "Description")
+                        .row("field", "String", "true", "Field.")
+                        .row("field2", "String", "true", "Field 2.")
+                        .row("field3", "String", "true", "Method 3.")
+                        .row("field4", "String", "true", "Method 4."));
 
         new JacksonResponseFieldSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
@@ -311,8 +341,8 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
                 .thenReturn(comment);
     }
 
-    private void mockMethodComment(Class<?> type, String fieldName, String comment) {
-        when(javadocReader.resolveMethodComment(type, fieldName))
+    private void mockMethodComment(Class<?> type, String methodName, String comment) {
+        when(javadocReader.resolveMethodComment(type, methodName))
                 .thenReturn(comment);
     }
 
@@ -321,8 +351,8 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
                 .thenReturn(comment);
     }
 
-    private void mockDeprecatedField(Class<?> type, String methodName, String comment) {
-        when(javadocReader.resolveFieldTag(type, methodName, "deprecated"))
+    private void mockDeprecatedField(Class<?> type, String fieldName, String comment) {
+        when(javadocReader.resolveFieldTag(type, fieldName, "deprecated"))
                 .thenReturn(comment);
     }
 
@@ -374,6 +404,10 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
         public DeprecatedItem removeItem() {
             return null;
         }
+
+        public CommentedItem commentItem() {
+            return null;
+        }
     }
 
     private static class Item {
@@ -389,18 +423,65 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
     }
 
     private static class DeprecatedItem {
+        // dep. annot on field, no getter
         @Deprecated
         private int index;
 
+        // dep. Javadoc on field, no getter
         private int index2;
+
+        // field, dep. annot on getter
+        private int index3;
+
+        // field, dep. Javadoc on getter
+        private int index4;
+
+        // dep. annot on field, getter
+        @Deprecated
+        private int index5;
 
         @Deprecated
         public int getIndex3() {
-            return index;
+            return index3;
         }
 
+        // deprecation Javadoc
         public int getIndex4() {
-            return index;
+            return index4;
+        }
+
+        public int getIndex5() {
+            return index5;
+        }
+
+        // no real field
+        @Deprecated
+        public int getIndex6() {
+            return 0;
+        }
+    }
+
+    private static class CommentedItem {
+        // comment on field only, no getter
+        private String field;
+
+        // comment on field, empty on getter
+        private String field2;
+
+        // comment on field and getter
+        private String field3;
+
+        public String getField2() {
+            return field2;
+        }
+
+        public String getField3() {
+            return field3;
+        }
+
+        // comment only on getter
+        public String getField4() {
+            return null;
         }
     }
 


### PR DESCRIPTION
when using lombok's Data or Getter, jackson returns `getField` instead of field itself. Therefore we need to infer field name to get the annotation from actual field.