### PR TITLE
1.0.14 Snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>capital.scalable</groupId>
     <artifactId>spring-auto-restdocs-parent</artifactId>
-    <version>1.0.13</version>
+    <version>1.0.14-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Spring Auto REST Docs Parent POM</name>

--- a/spring-auto-restdocs-core/pom.xml
+++ b/spring-auto-restdocs-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>capital.scalable</groupId>
         <artifactId>spring-auto-restdocs-parent</artifactId>
-        <version>1.0.13</version>
+        <version>1.0.14-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/spring-auto-restdocs-docs/pom.xml
+++ b/spring-auto-restdocs-docs/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <docs.dir>${project.basedir}/../docs</docs.dir>
-        <latestRelease>1.0.13</latestRelease> <!-- change this when releasing 1.0.13-SNAPSHOT -->
+        <latestRelease>1.0.13</latestRelease> <!-- change this when releasing 1.0.14-SNAPSHOT -->
     </properties>
 
     <build>

--- a/spring-auto-restdocs-json-doclet/pom.xml
+++ b/spring-auto-restdocs-json-doclet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>capital.scalable</groupId>
         <artifactId>spring-auto-restdocs-parent</artifactId>
-        <version>1.0.13</version>
+        <version>1.0.14-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 


### PR DESCRIPTION
The example project isn't set to the snapshot version intentionally. It is easier to work with the example if it is based on a release.