### PR TITLE
Handle not null Kotlin properties and Java Optional / nullable Kotlin parameters (1.0.x)

### DIFF
--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/FieldDocumentationVisitorContext.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/FieldDocumentationVisitorContext.java
@@ -84,7 +84,7 @@ class FieldDocumentationVisitorContext {
                 .description(comment);
 
         Attribute constraints = constraintAttribute(javaBaseClass, javaFieldName);
-        Attribute optionals = optionalAttribute(javaBaseClass, javaFieldName);
+        Attribute optionals = optionalAttribute(javaBaseClass, javaFieldName, info.isRequired());
         Attribute deprecated = deprecatedAttribute(javaBaseClass, javaFieldName);
         fieldDescriptor.attributes(constraints, optionals, deprecated);
 
@@ -110,9 +110,9 @@ class FieldDocumentationVisitorContext {
                 resolveConstraintDescriptions(javaBaseClass, javaFieldName));
     }
 
-    private Attribute optionalAttribute(Class<?> javaBaseClass, String javaFieldName) {
+    private Attribute optionalAttribute(Class<?> javaBaseClass, String javaFieldName, boolean requiredField) {
         return new Attribute(OPTIONAL_ATTRIBUTE,
-                resolveOptionalMessages(javaBaseClass, javaFieldName));
+                resolveOptionalMessages(javaBaseClass, javaFieldName, requiredField));
     }
 
     private Attribute deprecatedAttribute(Class<?> javaBaseClass, String javaFieldName) {
@@ -120,8 +120,13 @@ class FieldDocumentationVisitorContext {
                 resolveDeprecatedMessage(javaBaseClass, javaFieldName));
     }
 
-    private List<String> resolveOptionalMessages(Class<?> javaBaseClass, String javaFieldName) {
+    private List<String> resolveOptionalMessages(Class<?> javaBaseClass, String javaFieldName, boolean requiredField) {
         List<String> optionalMessages = new ArrayList<>();
+
+        if (requiredField) {
+            optionalMessages.add("false");
+            return optionalMessages;
+        }
 
         if (isPrimitive(javaBaseClass, javaFieldName)) {
             boolean failOnNullForPrimitives = deserializationConfig.hasDeserializationFeatures(

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/InternalFieldInfo.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/InternalFieldInfo.java
@@ -27,14 +27,20 @@ class InternalFieldInfo {
     private final JavaType javaFieldType;
     private final String jsonFieldPath;
     private final boolean shouldExpand;
+    /**
+     * True for required bean properties like fields annotated with @JsonProperty(required = true)
+     * or non-null properties in Kotlin.
+     */
+    private final boolean required;
 
     public InternalFieldInfo(Class<?> javaBaseClass, String javaFieldName, JavaType javaFieldType,
-            String jsonFieldPath, boolean shouldExpand) {
+            String jsonFieldPath, boolean shouldExpand, boolean required) {
         this.javaBaseClass = javaBaseClass;
         this.javaFieldName = javaFieldName;
         this.javaFieldType = javaFieldType;
         this.jsonFieldPath = jsonFieldPath;
         this.shouldExpand = shouldExpand;
+        this.required = required;
     }
 
     public Class<?> getJavaBaseClass() {
@@ -55,5 +61,9 @@ class InternalFieldInfo {
 
     public boolean shouldExpand() {
         return shouldExpand;
+    }
+
+    public boolean isRequired() {
+        return required;
     }
 }

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/AbstractParameterSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/AbstractParameterSnippet.java
@@ -84,7 +84,7 @@ abstract class AbstractParameterSnippet<A extends Annotation> extends StandardTa
         String pathName = getPath(annot);
 
         String parameterName = hasLength(pathName) ? pathName : javaParameterName;
-        String parameterTypeName = determineTypeName(param.getParameterType());
+        String parameterTypeName = determineTypeName(param.nestedIfOptional().getNestedParameterType());
         String description = javadocReader.resolveMethodParameterComment(
                 handlerMethod.getBeanType(), handlerMethod.getMethod().getName(),
                 javaParameterName);

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/PathParametersSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/PathParametersSnippet.java
@@ -42,8 +42,10 @@ public class PathParametersSnippet extends AbstractParameterSnippet<PathVariable
 
     @Override
     protected boolean isRequired(MethodParameter param, PathVariable annot) {
-        // Spring disallows null for primitive types
-        return param.getParameterType().isPrimitive() || annot.required();
+        // Spring disallows null for primitive types.
+        // For types wrapped in Optional or nullable Kotlin types, the required flag in
+        // the annotation is ignored by Spring.
+        return param.getParameterType().isPrimitive() || (!param.isOptional() && annot.required());
     }
 
     @Override

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/RequestHeaderSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/RequestHeaderSnippet.java
@@ -43,7 +43,9 @@ public class RequestHeaderSnippet extends AbstractParameterSnippet<RequestHeader
     @Override
     protected boolean isRequired(MethodParameter param, RequestHeader annot) {
         // Spring disallows null for primitive types
-        return param.getParameterType().isPrimitive() || annot.required();
+        // For types wrapped in Optional or nullable Kotlin types, the required flag in
+        // the annotation is ignored by Spring.
+        return param.getParameterType().isPrimitive() || (!param.isOptional() && annot.required());
     }
 
     @Override

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/RequestParametersSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/RequestParametersSnippet.java
@@ -57,7 +57,9 @@ public class RequestParametersSnippet extends AbstractParameterSnippet<RequestPa
             // the required flag
             return true;
         } else {
-            return annot.required();
+            // For Types wrapped in Optional or nullable Kotlin types, the required flag in
+            // the annotation is ignored by Spring.
+            return !param.isOptional() && annot.required();
         }
     }
 

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/jackson/FieldDocumentationGeneratorTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/jackson/FieldDocumentationGeneratorTest.java
@@ -458,6 +458,27 @@ public class FieldDocumentationGeneratorTest {
                         "true")));
     }
 
+    @Test
+    public void testGenerateDocumentationForRequiredProperties() throws Exception {
+        // given
+        ObjectMapper mapper = createMapper();
+        mockFieldComment(RequiredProperties.class, "string", "A string");
+        mockFieldComment(RequiredProperties.class, "number", "An integer");
+
+        FieldDocumentationGenerator generator =
+                new FieldDocumentationGenerator(mapper.writer(), mapper.getDeserializationConfig(),
+                        javadocReader, constraintReader);
+        Type type = RequiredProperties.class;
+
+        // when
+        List<ExtendedFieldDescriptor> result = cast(generator
+                .generateDocumentation(type, mapper.getTypeFactory()));
+        // then
+        assertThat(result.size(), is(2));
+        assertThat(result.get(0), is(descriptor("string", "String", "A string", "false")));
+        assertThat(result.get(1), is(descriptor("number", "Integer", "An integer", "false")));
+    }
+
     private OngoingStubbing<List<String>> mockOptional(Class<?> javaBaseClass, String fieldName,
             String value) {
         return when(constraintReader.getOptionalMessages(javaBaseClass, fieldName))
@@ -694,5 +715,12 @@ public class FieldDocumentationGeneratorTest {
 
     private static class JsonType2SubType2 extends JsonType2 {
         private String base2Sub2;
+    }
+
+    private static class RequiredProperties {
+        @JsonProperty(required = true)
+        private String string;
+        @JsonProperty(required = true)
+        private Integer number;
     }
 }

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/PathParametersSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/PathParametersSnippetTest.java
@@ -26,8 +26,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.Optional;
-
 import capital.scalable.restdocs.constraints.ConstraintReader;
 import capital.scalable.restdocs.javadoc.JavadocReader;
 import org.junit.Before;
@@ -65,21 +63,19 @@ public class PathParametersSnippetTest extends AbstractSnippetTests {
     @Test
     public void simpleRequest() throws Exception {
         HandlerMethod handlerMethod = createHandlerMethod("addItem", Integer.class, String.class,
-                int.class, String.class, Optional.class);
+                int.class, String.class);
         initParameters(handlerMethod);
         mockParamComment("addItem", "id", "An integer");
         mockParamComment("addItem", "otherId", "A string");
         mockParamComment("addItem", "partId", "An integer");
         mockParamComment("addItem", "yetAnotherId", "Another string");
-        mockParamComment("addItem", "optionalId", "Optional string");
 
         this.snippets.expect(PATH_PARAMETERS).withContents(
                 tableWithHeader("Parameter", "Type", "Optional", "Description")
                         .row("id", "Integer", "false", "An integer.")
                         .row("subid", "String", "false", "A string.")
                         .row("partId", "Integer", "false", "An integer.")
-                        .row("yetAnotherId", "String", "true", "Another string.")
-                        .row("optionalId", "String", "true", "Optional string."));
+                        .row("yetAnotherId", "String", "true", "Another string."));
 
         new PathParametersSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
@@ -131,12 +127,12 @@ public class PathParametersSnippetTest extends AbstractSnippetTests {
     @Test
     public void failOnUndocumentedParams() throws Exception {
         HandlerMethod handlerMethod = createHandlerMethod("addItem", Integer.class, String.class,
-                int.class, String.class, Optional.class);
+                int.class, String.class);
         initParameters(handlerMethod);
 
         thrown.expect(SnippetException.class);
         thrown.expectMessage(
-                "Following path parameters were not documented: [id, subid, partId, yetAnotherId, optionalId]");
+                "Following path parameters were not documented: [id, subid, partId, yetAnotherId]");
 
         new PathParametersSnippet().failOnUndocumentedParams(true).document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
@@ -194,8 +190,7 @@ public class PathParametersSnippetTest extends AbstractSnippetTests {
                 @PathVariable("subid") String otherId,
                 // partId is required anyway, because it's a primitive type
                 @PathVariable(required = false) int partId,
-                @PathVariable(required = false) String yetAnotherId,
-                @PathVariable Optional<String> optionalId) {
+                @PathVariable(required = false) String yetAnotherId) {
             // NOOP
         }
 

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/PathParametersSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/PathParametersSnippetTest.java
@@ -26,6 +26,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
+
 import capital.scalable.restdocs.constraints.ConstraintReader;
 import capital.scalable.restdocs.javadoc.JavadocReader;
 import org.junit.Before;
@@ -63,19 +65,21 @@ public class PathParametersSnippetTest extends AbstractSnippetTests {
     @Test
     public void simpleRequest() throws Exception {
         HandlerMethod handlerMethod = createHandlerMethod("addItem", Integer.class, String.class,
-                int.class, String.class);
+                int.class, String.class, Optional.class);
         initParameters(handlerMethod);
         mockParamComment("addItem", "id", "An integer");
         mockParamComment("addItem", "otherId", "A string");
         mockParamComment("addItem", "partId", "An integer");
         mockParamComment("addItem", "yetAnotherId", "Another string");
+        mockParamComment("addItem", "optionalId", "Optional string");
 
         this.snippets.expect(PATH_PARAMETERS).withContents(
                 tableWithHeader("Parameter", "Type", "Optional", "Description")
                         .row("id", "Integer", "false", "An integer.")
                         .row("subid", "String", "false", "A string.")
                         .row("partId", "Integer", "false", "An integer.")
-                        .row("yetAnotherId", "String", "true", "Another string."));
+                        .row("yetAnotherId", "String", "true", "Another string.")
+                        .row("optionalId", "String", "true", "Optional string."));
 
         new PathParametersSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
@@ -127,12 +131,12 @@ public class PathParametersSnippetTest extends AbstractSnippetTests {
     @Test
     public void failOnUndocumentedParams() throws Exception {
         HandlerMethod handlerMethod = createHandlerMethod("addItem", Integer.class, String.class,
-                int.class, String.class);
+                int.class, String.class, Optional.class);
         initParameters(handlerMethod);
 
         thrown.expect(SnippetException.class);
         thrown.expectMessage(
-                "Following path parameters were not documented: [id, subid, partId, yetAnotherId]");
+                "Following path parameters were not documented: [id, subid, partId, yetAnotherId, optionalId]");
 
         new PathParametersSnippet().failOnUndocumentedParams(true).document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
@@ -185,12 +189,13 @@ public class PathParametersSnippetTest extends AbstractSnippetTests {
             SPHERIC, SQUARE
         }
 
-        @PostMapping("/items/{id}/subitem/{subid}/{partId}/{yetAnotherId}")
+        @PostMapping("/items/{id}/subitem/{subid}/{partId}/{yetAnotherId}/{optionalId}")
         public void addItem(@PathVariable Integer id,
                 @PathVariable("subid") String otherId,
                 // partId is required anyway, because it's a primitive type
                 @PathVariable(required = false) int partId,
-                @PathVariable(required = false) String yetAnotherId) {
+                @PathVariable(required = false) String yetAnotherId,
+                @PathVariable Optional<String> optionalId) {
             // NOOP
         }
 

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/RequestHeaderSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/RequestHeaderSnippetTest.java
@@ -25,8 +25,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.Optional;
-
 import capital.scalable.restdocs.constraints.ConstraintReader;
 import capital.scalable.restdocs.javadoc.JavadocReader;
 import org.junit.Before;
@@ -63,13 +61,12 @@ public class RequestHeaderSnippetTest extends AbstractSnippetTests {
     @Test
     public void simpleRequest() throws Exception {
         HandlerMethod handlerMethod = createHandlerMethod("updateItem", Integer.class, String.class,
-                int.class, String.class, Optional.class);
+                int.class, String.class);
         initParameters(handlerMethod);
         mockParamComment("updateItem", "id", "An integer");
         mockParamComment("updateItem", "otherId", "A string");
         mockParamComment("updateItem", "partId", "An integer");
         mockParamComment("updateItem", "yetAnotherId", "A string");
-        mockParamComment("updateItem", "optionalId", "Optional string");
 
         this.snippets.expect(REQUEST_HEADERS).withContents(
                 tableWithHeader("Header", "Type", "Optional", "Description")
@@ -77,8 +74,7 @@ public class RequestHeaderSnippetTest extends AbstractSnippetTests {
                         .row("subId", "String", "false", "A string.")
                         .row("partId", "Integer", "false", "An integer.")
                         .row("yetAnotherId", "String", "true",
-                                "A string.\n\nDefault value: 'ID'.")
-                        .row("optionalId", "String", "true", "Optional string."));
+                                "A string.\n\nDefault value: 'ID'."));
 
         new RequestHeaderSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
@@ -90,7 +86,7 @@ public class RequestHeaderSnippetTest extends AbstractSnippetTests {
     @Test
     public void simpleRequestDefaultValueParameterNotDocumented() throws Exception {
         HandlerMethod handlerMethod = createHandlerMethod("updateItem", Integer.class, String.class,
-                int.class, String.class, Optional.class);
+                int.class, String.class);
         initParameters(handlerMethod);
         mockParamComment("updateItem", "id", "An integer");
         mockParamComment("updateItem", "otherId", "A string");
@@ -102,8 +98,7 @@ public class RequestHeaderSnippetTest extends AbstractSnippetTests {
                         .row("id", "Integer", "false", "An integer.")
                         .row("subId", "String", "false", "A string.")
                         .row("partId", "Integer", "false", "An integer.")
-                        .row("yetAnotherId", "String", "true", "Default value: 'ID'.")
-                        .row("optionalId", "String", "true", ""));
+                        .row("yetAnotherId", "String", "true", "Default value: 'ID'."));
 
         new RequestHeaderSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
@@ -188,8 +183,7 @@ public class RequestHeaderSnippetTest extends AbstractSnippetTests {
                 @RequestHeader("subId") String otherId,
                 @RequestHeader(required = false) int partId,
                 // required anyway, because it's a primitive type
-                @RequestHeader(required = false, defaultValue = "ID") String yetAnotherId,
-                @RequestHeader Optional<String> optionalId) {
+                @RequestHeader(required = false, defaultValue = "ID") String yetAnotherId) {
             // NOOP
         }
 

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/RequestHeaderSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/RequestHeaderSnippetTest.java
@@ -25,6 +25,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
+
 import capital.scalable.restdocs.constraints.ConstraintReader;
 import capital.scalable.restdocs.javadoc.JavadocReader;
 import org.junit.Before;
@@ -61,12 +63,13 @@ public class RequestHeaderSnippetTest extends AbstractSnippetTests {
     @Test
     public void simpleRequest() throws Exception {
         HandlerMethod handlerMethod = createHandlerMethod("updateItem", Integer.class, String.class,
-                int.class, String.class);
+                int.class, String.class, Optional.class);
         initParameters(handlerMethod);
         mockParamComment("updateItem", "id", "An integer");
         mockParamComment("updateItem", "otherId", "A string");
         mockParamComment("updateItem", "partId", "An integer");
         mockParamComment("updateItem", "yetAnotherId", "A string");
+        mockParamComment("updateItem", "optionalId", "Optional string");
 
         this.snippets.expect(REQUEST_HEADERS).withContents(
                 tableWithHeader("Header", "Type", "Optional", "Description")
@@ -74,7 +77,8 @@ public class RequestHeaderSnippetTest extends AbstractSnippetTests {
                         .row("subId", "String", "false", "A string.")
                         .row("partId", "Integer", "false", "An integer.")
                         .row("yetAnotherId", "String", "true",
-                                "A string.\n\nDefault value: 'ID'."));
+                                "A string.\n\nDefault value: 'ID'.")
+                        .row("optionalId", "String", "true", "Optional string."));
 
         new RequestHeaderSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
@@ -86,7 +90,7 @@ public class RequestHeaderSnippetTest extends AbstractSnippetTests {
     @Test
     public void simpleRequestDefaultValueParameterNotDocumented() throws Exception {
         HandlerMethod handlerMethod = createHandlerMethod("updateItem", Integer.class, String.class,
-                int.class, String.class);
+                int.class, String.class, Optional.class);
         initParameters(handlerMethod);
         mockParamComment("updateItem", "id", "An integer");
         mockParamComment("updateItem", "otherId", "A string");
@@ -98,7 +102,8 @@ public class RequestHeaderSnippetTest extends AbstractSnippetTests {
                         .row("id", "Integer", "false", "An integer.")
                         .row("subId", "String", "false", "A string.")
                         .row("partId", "Integer", "false", "An integer.")
-                        .row("yetAnotherId", "String", "true", "Default value: 'ID'."));
+                        .row("yetAnotherId", "String", "true", "Default value: 'ID'.")
+                        .row("optionalId", "String", "true", ""));
 
         new RequestHeaderSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
@@ -183,7 +188,8 @@ public class RequestHeaderSnippetTest extends AbstractSnippetTests {
                 @RequestHeader("subId") String otherId,
                 @RequestHeader(required = false) int partId,
                 // required anyway, because it's a primitive type
-                @RequestHeader(required = false, defaultValue = "ID") String yetAnotherId) {
+                @RequestHeader(required = false, defaultValue = "ID") String yetAnotherId,
+                @RequestHeader Optional<String> optionalId) {
             // NOOP
         }
 

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/RequestParametersSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/RequestParametersSnippetTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Locale;
+import java.util.Optional;
 
 import capital.scalable.restdocs.constraints.ConstraintReader;
 import capital.scalable.restdocs.javadoc.JavadocReader;
@@ -185,6 +186,23 @@ public class RequestParametersSnippetTest extends AbstractSnippetTests {
     }
 
     @Test
+    public void simpleRequestWithOptional() throws Exception {
+        HandlerMethod handlerMethod = createHandlerMethod("searchItemOptional", Optional.class);
+        initParameters(handlerMethod);
+        mockParamComment("searchItemOptional", "param1", "An optional string");
+
+        this.snippets.expect(REQUEST_PARAMETERS).withContents(
+                tableWithHeader("Parameter", "Type", "Optional", "Description")
+                        .row("param1", "String", "true", "An optional string."));
+
+        new RequestParametersSnippet().document(operationBuilder
+                .attribute(HandlerMethod.class.getName(), handlerMethod)
+                .attribute(JavadocReader.class.getName(), javadocReader)
+                .attribute(ConstraintReader.class.getName(), constraintReader)
+                .build());
+    }
+
+    @Test
     public void noParameters() throws Exception {
         HandlerMethod handlerMethod = createHandlerMethod("items");
 
@@ -303,20 +321,32 @@ public class RequestParametersSnippetTest extends AbstractSnippetTests {
             SMALL, LARGE
         }
 
-        public void searchItem(@RequestParam Integer type,
+        public void searchItem(
+                @RequestParam Integer type,
                 @RequestParam(value = "text", required = false) String description) {
             // NOOP
         }
 
-        public void searchItem2(@RequestParam double param1,    // required
+        public void searchItem2(
+                @RequestParam double param1,                    // required
                 @RequestParam(required = false) boolean param2, // required anyway
                 @RequestParam(defaultValue = "1") int param3) { // not required
             // NOOP
         }
 
-        public void searchItem2String(@RequestParam double param1,    // required
-                @RequestParam(required = false) boolean param2, // required anyway
+        public void searchItem2String(
+                @RequestParam double param1,                        // required
+                @RequestParam(required = false) boolean param2,     // required anyway
                 @RequestParam(defaultValue = "de") String param3) { // not required
+            // NOOP
+        }
+
+        public void searchItemOptional(
+                /**
+                 * A nullable Kotlin type is interpreted like a Java type
+                 * wrapped in Optional and thus not required.
+                 */
+                @RequestParam Optional<String> param1) { // not required
             // NOOP
         }
 

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/RequestParametersSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/request/RequestParametersSnippetTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Locale;
-import java.util.Optional;
 
 import capital.scalable.restdocs.constraints.ConstraintReader;
 import capital.scalable.restdocs.javadoc.JavadocReader;
@@ -186,23 +185,6 @@ public class RequestParametersSnippetTest extends AbstractSnippetTests {
     }
 
     @Test
-    public void simpleRequestWithOptional() throws Exception {
-        HandlerMethod handlerMethod = createHandlerMethod("searchItemOptional", Optional.class);
-        initParameters(handlerMethod);
-        mockParamComment("searchItemOptional", "param1", "An optional string");
-
-        this.snippets.expect(REQUEST_PARAMETERS).withContents(
-                tableWithHeader("Parameter", "Type", "Optional", "Description")
-                        .row("param1", "String", "true", "An optional string."));
-
-        new RequestParametersSnippet().document(operationBuilder
-                .attribute(HandlerMethod.class.getName(), handlerMethod)
-                .attribute(JavadocReader.class.getName(), javadocReader)
-                .attribute(ConstraintReader.class.getName(), constraintReader)
-                .build());
-    }
-
-    @Test
     public void noParameters() throws Exception {
         HandlerMethod handlerMethod = createHandlerMethod("items");
 
@@ -338,15 +320,6 @@ public class RequestParametersSnippetTest extends AbstractSnippetTests {
                 @RequestParam double param1,                        // required
                 @RequestParam(required = false) boolean param2,     // required anyway
                 @RequestParam(defaultValue = "de") String param3) { // not required
-            // NOOP
-        }
-
-        public void searchItemOptional(
-                /**
-                 * A nullable Kotlin type is interpreted like a Java type
-                 * wrapped in Optional and thus not required.
-                 */
-                @RequestParam Optional<String> param1) { // not required
             // NOOP
         }
 


### PR DESCRIPTION
Backport of https://github.com/ScaCap/spring-auto-restdocs/pull/230

I had to remove tests and parts of tests that used Optional, because Java 7 is the baseline for 1.0.x.