### PR TITLE
Improve addDot

### DIFF
--- a/samples/java-webmvc/generated-docs/index.html
+++ b/samples/java-webmvc/generated-docs/index.html
@@ -859,6 +859,22 @@ Content-Length: 459
 <div class="paragraph">
 <p>This endpoint really returns all items and that is always 100.</p>
 </div>
+<div class="paragraph">
+<p>Returns list of all items.</p>
+</div>
+<div class="paragraph">
+<p>Use query parameters to filter the list by:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>orderNumber</p>
+</li>
+<li>
+<p>type</p>
+</li>
+</ul>
+</div>
 <div class="sect3">
 <h4 id="_authorization_2"><a class="anchor" href="#_authorization_2"></a><a class="link" href="#_authorization_2">2.2.1. Authorization</a></h4>
 <div class="paragraph">
@@ -1129,7 +1145,7 @@ Size must be between 0 and 1000 inclusive.</p></td>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items' -i -X POST \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer c55135fc-a938-4c0e-aee5-0b97df74978e' \
+    -H 'Authorization: Bearer 55ad9296-b11a-4713-8370-a6c617d9656a' \
     -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
@@ -1366,7 +1382,7 @@ Must be at most 10.</p></td>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X PUT \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer c55135fc-a938-4c0e-aee5-0b97df74978e' \
+    -H 'Authorization: Bearer 55ad9296-b11a-4713-8370-a6c617d9656a' \
     -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
@@ -1472,7 +1488,7 @@ Item must exist.</p>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X DELETE \
-    -H 'Authorization: Bearer c55135fc-a938-4c0e-aee5-0b97df74978e'</code></pre>
+    -H 'Authorization: Bearer 55ad9296-b11a-4713-8370-a6c617d9656a'</code></pre>
 </div>
 </div>
 </div>
@@ -1497,23 +1513,13 @@ X-Frame-Options: DENY</code></pre>
 <p><code>GET /items/{id}/{child}</code></p>
 </div>
 <div class="paragraph">
-<p>Returns list of all items.</p>
+<p>Retrieves a child of specified item.</p>
 </div>
 <div class="paragraph">
-<p>Use query parameters to filter the list by:</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p>orderNumber</p>
-</li>
-<li>
-<p>type</p>
-</li>
-</ul>
+<p>An example of using parameter validation.</p>
 </div>
 <div class="paragraph">
-<p>.</p>
+<p>See <a href="https://scacap.github.io/spring-auto-restdocs/#constraints">constraints documentation</a>.</p>
 </div>
 <div class="sect3">
 <h4 id="_authorization_6"><a class="anchor" href="#_authorization_6"></a><a class="link" href="#_authorization_6">2.6.1. Authorization</a></h4>
@@ -1543,13 +1549,15 @@ X-Frame-Options: DENY</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock">id</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Must be a valid ID.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Item ID.</p>
+<p class="tableblock">Must be a valid ID.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">child</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">DE: Must be at most 2.<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Child ID.</p>
+<p class="tableblock">DE: Must be at most 2.<br>
 EN: Must be at least 1.</p></td>
 </tr>
 </tbody>
@@ -1976,9 +1984,9 @@ Content-Length: 1011
     "unpaged" : false
   },
   "total" : 1,
-  "last" : true,
   "totalPages" : 1,
   "totalElements" : 1,
+  "last" : true,
   "first" : true,
   "sort" : {
     "orders" : [ ],

--- a/samples/java-webmvc/generated-docs/index.html
+++ b/samples/java-webmvc/generated-docs/index.html
@@ -804,7 +804,7 @@ Must be at most 10.</p></td>
 <h4 id="_example_request_response"><a class="anchor" href="#_example_request_response"></a><a class="link" href="#_example_request_response">2.1.5. Example request/response</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i</code></pre>
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X GET</code></pre>
 </div>
 </div>
 <div class="listingblock">
@@ -994,7 +994,7 @@ Must be at most 10.</p></td>
 <h4 id="_example_request_response_2"><a class="anchor" href="#_example_request_response_2"></a><a class="link" href="#_example_request_response_2">2.2.4. Example request/response</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items' -i</code></pre>
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items' -i -X GET</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1129,7 +1129,7 @@ Size must be between 0 and 1000 inclusive.</p></td>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items' -i -X POST \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer 23d918a4-653f-4e61-9b46-b5e72fd2ba7c' \
+    -H 'Authorization: Bearer c55135fc-a938-4c0e-aee5-0b97df74978e' \
     -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
@@ -1366,7 +1366,7 @@ Must be at most 10.</p></td>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X PUT \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer 23d918a4-653f-4e61-9b46-b5e72fd2ba7c' \
+    -H 'Authorization: Bearer c55135fc-a938-4c0e-aee5-0b97df74978e' \
     -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
@@ -1472,7 +1472,7 @@ Item must exist.</p>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X DELETE \
-    -H 'Authorization: Bearer 23d918a4-653f-4e61-9b46-b5e72fd2ba7c'</code></pre>
+    -H 'Authorization: Bearer c55135fc-a938-4c0e-aee5-0b97df74978e'</code></pre>
 </div>
 </div>
 </div>
@@ -1497,13 +1497,23 @@ X-Frame-Options: DENY</code></pre>
 <p><code>GET /items/{id}/{child}</code></p>
 </div>
 <div class="paragraph">
-<p>Retrieves a child of specified item.</p>
+<p>Returns list of all items.</p>
 </div>
 <div class="paragraph">
-<p>An example of using parameter validation.</p>
+<p>Use query parameters to filter the list by:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>orderNumber</p>
+</li>
+<li>
+<p>type</p>
+</li>
+</ul>
 </div>
 <div class="paragraph">
-<p>See <a href="https://scacap.github.io/spring-auto-restdocs/#constraints">constraints documentation</a>.</p>
+<p>.</p>
 </div>
 <div class="sect3">
 <h4 id="_authorization_6"><a class="anchor" href="#_authorization_6"></a><a class="link" href="#_authorization_6">2.6.1. Authorization</a></h4>
@@ -1533,15 +1543,13 @@ X-Frame-Options: DENY</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock">id</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Item ID.</p>
-<p class="tableblock">Must be a valid ID.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Must be a valid ID.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">child</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Child ID.</p>
-<p class="tableblock">DE: Must be at most 2.<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">DE: Must be at most 2.<br>
 EN: Must be at least 1.</p></td>
 </tr>
 </tbody>
@@ -1682,7 +1690,7 @@ Must be at most 10.</p></td>
 <h4 id="_example_request_4"><a class="anchor" href="#_example_request_4"></a><a class="link" href="#_example_request_4">2.6.6. Example request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/1/child-1' -i</code></pre>
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/1/child-1' -i -X GET</code></pre>
 </div>
 </div>
 </div>
@@ -1909,7 +1917,7 @@ Must be at most 10.</p></td>
 <h4 id="_example_request_5"><a class="anchor" href="#_example_request_5"></a><a class="link" href="#_example_request_5">2.7.6. Example request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/search?desc=main&amp;hint=1' -i</code></pre>
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/search?desc=main&amp;hint=1' -i -X GET</code></pre>
 </div>
 </div>
 </div>
@@ -1961,25 +1969,25 @@ Content-Length: 1011
       "sorted" : false,
       "unsorted" : true
     },
-    "offset" : 0,
     "pageSize" : 20,
     "pageNumber" : 0,
+    "offset" : 0,
     "paged" : true,
     "unpaged" : false
   },
   "total" : 1,
-  "totalElements" : 1,
-  "totalPages" : 1,
   "last" : true,
-  "size" : 20,
-  "number" : 0,
-  "numberOfElements" : 1,
+  "totalPages" : 1,
+  "totalElements" : 1,
+  "first" : true,
   "sort" : {
     "orders" : [ ],
     "sorted" : false,
     "unsorted" : true
   },
-  "first" : true
+  "numberOfElements" : 1,
+  "size" : 20,
+  "number" : 0
 }</code></pre>
 </div>
 </div>
@@ -2471,7 +2479,7 @@ the cURL and HTTP response are coming from Spring REST Docs in any case.</p>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>+id+</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">ID of the item.</p></td>
 </tr>
 </tbody>
@@ -2494,8 +2502,8 @@ the cURL and HTTP response are coming from Spring REST Docs in any case.</p>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>id</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>+id+</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>+String+</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">There are more fields but only the ID field is documented.</p></td>
 </tr>
 </tbody>
@@ -2505,7 +2513,7 @@ the cURL and HTTP response are coming from Spring REST Docs in any case.</p>
 <h4 id="_example_request_response_3"><a class="anchor" href="#_example_request_response_3"></a><a class="link" href="#_example_request_response_3">2.12.4. Example request/response</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i</code></pre>
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X GET</code></pre>
 </div>
 </div>
 <div class="listingblock">
@@ -2554,7 +2562,7 @@ Content-Length: 459
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2018-03-29 11:51:15 CEST
+Last updated 2018-06-15 10:19:16 MESZ
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css">

--- a/samples/java-webmvc/src/main/asciidoc/items.adoc
+++ b/samples/java-webmvc/src/main/asciidoc/items.adoc
@@ -40,6 +40,8 @@ As AsciiDoc is used, any additional information can be placed here and you don't
 
 This endpoint really returns all items and that is always 100.
 
+include::{snippets}/item-resource-test/get-all-items/auto-description.adoc[]
+
 ==== Authorization
 
 include::{snippets}/item-resource-test/get-all-items/auto-authorization.adoc[]

--- a/samples/java-webmvc/src/main/java/capital/scalable/restdocs/example/items/ItemResource.java
+++ b/samples/java-webmvc/src/main/java/capital/scalable/restdocs/example/items/ItemResource.java
@@ -92,9 +92,13 @@ public class ItemResource {
     }
 
     /**
-     * Lists all items.
-     * <p>
-     * An example of retuning an array/collection.
+	 * Returns list of all items.
+	 * <p>
+	 * Use query parameters to filter the list by:
+	 * <ul>
+	 *   <li>orderNumber</li>
+	 *   <li>type</li>
+	 * </ul>
      *
      * @return list of all items
      */
@@ -163,12 +167,6 @@ public class ItemResource {
      * Retrieves a child of specified item.
      * <p>
      * An example of using parameter validation.
-     * <p>
-     * Result:
-     * <ul>
-     * <li>200 OK: Success</li>
-     * <li>404 Not Found: Child or Parent not found</li>
-     * </ul>
      *
      * @param id      Item ID.
      * @param childId Child ID.

--- a/samples/java-webmvc/src/main/java/capital/scalable/restdocs/example/items/ItemResource.java
+++ b/samples/java-webmvc/src/main/java/capital/scalable/restdocs/example/items/ItemResource.java
@@ -92,13 +92,13 @@ public class ItemResource {
     }
 
     /**
-	 * Returns list of all items.
-	 * <p>
-	 * Use query parameters to filter the list by:
-	 * <ul>
-	 *   <li>orderNumber</li>
-	 *   <li>type</li>
-	 * </ul>
+     * Returns list of all items.
+     * <p>
+     * Use query parameters to filter the list by:
+     * <ul>
+     * <li>orderNumber</li>
+     * <li>type</li>
+     * </ul>
      *
      * @return list of all items
      */

--- a/samples/java-webmvc/src/main/java/capital/scalable/restdocs/example/items/ItemResource.java
+++ b/samples/java-webmvc/src/main/java/capital/scalable/restdocs/example/items/ItemResource.java
@@ -163,6 +163,12 @@ public class ItemResource {
      * Retrieves a child of specified item.
      * <p>
      * An example of using parameter validation.
+     * <p>
+     * Result:
+     * <ul>
+     * <li>200 OK: Success</li>
+     * <li>404 Not Found: Child or Parent not found</li>
+     * </ul>
      *
      * @param id      Item ID.
      * @param childId Child ID.

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/util/FormatUtil.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/util/FormatUtil.java
@@ -39,7 +39,7 @@ public class FormatUtil {
     }
 
     public static String addDot(String text) {
-        return isNotBlank(text) && !text.endsWith(".") && !text.endsWith(" ")
+        return isNotBlank(text) && !text.matches("^(?s).*(?:[.?!:;)\"]|</(?:p|ul|ol)>)\\s*$") && !text.endsWith(" ")
                 ? text + "."
                 : text;
     }

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/util/FormatUtilTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/util/FormatUtilTest.java
@@ -44,8 +44,21 @@ public class FormatUtilTest {
         assertThat(FormatUtil.addDot("."), is("."));
         assertThat(FormatUtil.addDot("text."), is("text."));
         assertThat(FormatUtil.addDot("text"), is("text."));
+        assertThat(FormatUtil.addDot("text?"), is("text?"));
+        assertThat(FormatUtil.addDot("text!"), is("text!"));
+        assertThat(FormatUtil.addDot("text:"), is("text:"));
+        assertThat(FormatUtil.addDot("text;"), is("text;"));
+        assertThat(FormatUtil.addDot("text)"), is("text)"));
+        assertThat(FormatUtil.addDot("text\""), is("text\""));
+        assertThat(FormatUtil.addDot("text+"), is("text+."));
         assertThat(FormatUtil.addDot("text with html:\n<ul>\n<li>first</li>\n<li>second</li>\n</ul>"),
                 is("text with html:\n<ul>\n<li>first</li>\n<li>second</li>\n</ul>"));
+        assertThat(FormatUtil.addDot("text with html:\r\n<ul>\r\n<li>first</li>\r\n<li>second</li>\r\n</ul>"),
+                is("text with html:\r\n<ul>\r\n<li>first</li>\r\n<li>second</li>\r\n</ul>"));
+        assertThat(FormatUtil.addDot("text with html:\r\n<ol>\r\n<li>first</li>\r\n<li>second</li>\r\n</ol>"),
+                is("text with html:\r\n<ol>\r\n<li>first</li>\r\n<li>second</li>\r\n</ol>"));
+        assertThat(FormatUtil.addDot("text with html:\r\n<p>another paragraph</p>"),
+                is("text with html:\r\n<p>another paragraph</p>"));
     }
 
     @Test

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/util/FormatUtilTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/util/FormatUtilTest.java
@@ -45,7 +45,7 @@ public class FormatUtilTest {
         assertThat(FormatUtil.addDot("text."), is("text."));
         assertThat(FormatUtil.addDot("text"), is("text."));
         assertThat(FormatUtil.addDot("text with html:\n<ul>\n<li>first</li>\n<li>second</li>\n</ul>"),
-				is("text with html:\n<ul>\n<li>first</li>\n<li>second</li>\n</ul>"));
+                is("text with html:\n<ul>\n<li>first</li>\n<li>second</li>\n</ul>"));
     }
 
     @Test

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/util/FormatUtilTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/util/FormatUtilTest.java
@@ -44,6 +44,8 @@ public class FormatUtilTest {
         assertThat(FormatUtil.addDot("."), is("."));
         assertThat(FormatUtil.addDot("text."), is("text."));
         assertThat(FormatUtil.addDot("text"), is("text."));
+        assertThat(FormatUtil.addDot("text with html:\n<ul>\n<li>first</li>\n<li>second</li>\n</ul>"),
+				is("text with html:\n<ul>\n<li>first</li>\n<li>second</li>\n</ul>"));
     }
 
     @Test


### PR DESCRIPTION
Currently the [`addDot`](https://github.com/ScaCap/spring-auto-restdocs/blob/master/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/util/FormatUtil.java#L41-L45) method adds a dot if the string not already ends with a dot or space.

So if you don't want to get this dot added to your description you could add a space to the end of the comment. But lines ending with a space violate some coding guidelines (like [checkstyle rules used by springframework](https://github.com/spring-io/spring-javaformat/blob/master/src/checkstyle/checkstyle.xml#L147-L151)). So I think this is not the best switch to avoid adding a dot to the end.

Have a look in the official documentation of spring-auto-restdocs: In the Section [Description snippet](https://scacap.github.io/spring-auto-restdocs/#snippets-description) there is an example but the result shown there is not correct. Currently it looks like this:
![wrong_dot_after_list](https://user-images.githubusercontent.com/1203740/41644851-9c0d1bcc-746f-11e8-93ed-0c36e0ccc58e.png)
(I have marked the dot, otherwise it could simply be missed)

This pull request adjusts the `addDot` method to not add a dot if the string is not empty and not ends with `.`, `?`, `!`, `:`, `;`, `)`, `"`, `</p>`, `</ul>` or `</ol>` (optionally followed by spaces). As before a dot is also not added if the string ends with a space.