### PR TITLE
Make SnippetRegistry extendable

### DIFF
--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/SnippetRegistry.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/SnippetRegistry.java
@@ -84,6 +84,10 @@ public class SnippetRegistry {
         }
     }
 
+    public static void addClassicSnippet(SectionSupport snippet) {
+        CLASSIC_SNIPPETS.put(snippet.getFileName(), snippet);
+    }
+
     private SnippetRegistry() {
         // constants
     }

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/SnippetRegistry.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/SnippetRegistry.java
@@ -38,6 +38,7 @@ public class SnippetRegistry {
     public static final String HTTP_REQUEST = "http-request";
     public static final String HTTP_RESPONSE = "http-response";
     public static final String HTTPIE_REQUEST = "httpie-request";
+    public static final String LINKS = "links";
 
     private static final Map<String, SectionSupport> CLASSIC_SNIPPETS;
 
@@ -47,6 +48,7 @@ public class SnippetRegistry {
         CLASSIC_SNIPPETS.put(HTTPIE_REQUEST, section(HTTPIE_REQUEST, "example-request", true));
         CLASSIC_SNIPPETS.put(HTTP_REQUEST, section(HTTP_REQUEST, "example-request", true));
         CLASSIC_SNIPPETS.put(HTTP_RESPONSE, section(HTTP_RESPONSE, "example-response", true));
+        CLASSIC_SNIPPETS.put(LINKS, section(LINKS, "hypermedia-links", true));
     }
 
     public static SectionSupport getClassicSnippet(String snippetName) {

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/FieldDocumentationObjectVisitor.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/FieldDocumentationObjectVisitor.java
@@ -33,9 +33,14 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 import org.slf4j.Logger;
 import org.springframework.util.Assert;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 class FieldDocumentationObjectVisitor extends JsonObjectFormatVisitor.Base {
     private static final Logger log = getLogger(FieldDocumentationObjectVisitor.class);
 
+    private final static Set<String> SKIPPED_FIELDS = new HashSet<>(Arrays.asList("_links", "_embedded"));
     private final FieldDocumentationVisitorContext context;
     private final String path;
     private final TypeRegistry typeRegistry;
@@ -104,6 +109,7 @@ class FieldDocumentationObjectVisitor extends JsonObjectFormatVisitor.Base {
     }
 
     private boolean shouldExpand(BeanProperty prop) {
-        return prop.getMember().getAnnotation(RestdocsNotExpanded.class) == null;
+        return prop.getMember().getAnnotation(RestdocsNotExpanded.class) == null
+                && !SKIPPED_FIELDS.contains(prop.getName());
     }
 }

--- a/spring-auto-restdocs-core/src/main/resources/capital/scalable/restdocs/i18n/DefaultSnippetMessages.properties
+++ b/spring-auto-restdocs-core/src/main/resources/capital/scalable/restdocs/i18n/DefaultSnippetMessages.properties
@@ -26,3 +26,4 @@ tags-deprecated=<b>Deprecated.</b> {0}
 tags-deprecated-title={0} (deprecated)
 tags-see=See {0}
 default-value=Default value: ''{0}''
+hypermedia-links=Hypermedia links

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/section/SectionSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/section/SectionSnippetTest.java
@@ -40,6 +40,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import capital.scalable.restdocs.SnippetRegistry;
 import capital.scalable.restdocs.i18n.TranslationRule;
 import capital.scalable.restdocs.javadoc.JavadocReader;
 import org.junit.Before;
@@ -175,6 +176,56 @@ public class SectionSnippetTest {
 
         new SectionBuilder()
                 .snippetNames(HTTP_RESPONSE, RESPONSE_FIELDS, HTTP_REQUEST)
+                .build()
+                .document(operationBuilder
+                        .attribute(HandlerMethod.class.getName(), handlerMethod)
+                        .attribute(JavadocReader.class.getName(), javadocReader)
+                        .attribute(ATTRIBUTE_NAME_DEFAULT_SNIPPETS, Arrays.asList(
+                                pathParameters(), requestParameters(),
+                                requestFields(), responseFields(), curlRequest(),
+                                HttpDocumentation.httpRequest(), HttpDocumentation.httpResponse()))
+                        .request("http://localhost/items/1")
+                        .build());
+    }
+
+    @Test
+    public void additionalClassicSnippets() throws Exception {
+        translationRule.setTestTranslations();
+        HandlerMethod handlerMethod = new HandlerMethod(new TestResource(), "getItemById");
+        mockMethodTitle(TestResource.class, "getItemById", "");
+        SnippetRegistry.addClassicSnippet(new SectionSupport() {
+            @Override
+            public String getFileName() {
+                return "my-snippet-name";
+            }
+
+            @Override
+            public String getHeaderKey() {
+                return "my-snippet-header-key";
+            }
+
+            @Override
+            public boolean hasContent(Operation operation) {
+                return true;
+            }
+        });
+
+        this.snippets.expect(SECTION)
+                .withContents(equalTo("[[resources-additionalClassicSnippets]]\n" +
+                        "=== Get Item By Id\n\n" +
+                        "include::auto-method-path.adoc[]\n\n" +
+                        "include::auto-description.adoc[]\n\n" +
+                        "==== XExample response\n\n" +
+                        "include::http-response.adoc[]\n\n" +
+                        "==== XResponse fields\n\n" +
+                        "include::auto-response-fields.adoc[]\n\n" +
+                        "==== XExample request\n\n" +
+                        "include::http-request.adoc[]\n\n" +
+                        "==== My snippet\n\n" +
+                        "include::my-snippet-name.adoc[]\n"));
+
+        new SectionBuilder()
+                .snippetNames(HTTP_RESPONSE, RESPONSE_FIELDS, HTTP_REQUEST, "my-snippet-name")
                 .build()
                 .document(operationBuilder
                         .attribute(HandlerMethod.class.getName(), handlerMethod)

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/section/SectionSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/section/SectionSnippetTest.java
@@ -26,6 +26,7 @@ import static capital.scalable.restdocs.AutoDocumentation.requestParameters;
 import static capital.scalable.restdocs.AutoDocumentation.responseFields;
 import static capital.scalable.restdocs.SnippetRegistry.HTTP_REQUEST;
 import static capital.scalable.restdocs.SnippetRegistry.HTTP_RESPONSE;
+import static capital.scalable.restdocs.SnippetRegistry.LINKS;
 import static capital.scalable.restdocs.SnippetRegistry.RESPONSE_FIELDS;
 import static capital.scalable.restdocs.section.SectionSnippet.SECTION;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -49,6 +50,7 @@ import org.junit.Test;
 import org.junit.runners.Parameterized;
 import org.springframework.restdocs.AbstractSnippetTests;
 import org.springframework.restdocs.http.HttpDocumentation;
+import org.springframework.restdocs.operation.Operation;
 import org.springframework.restdocs.templates.TemplateFormat;
 import org.springframework.restdocs.templates.TemplateFormats;
 import org.springframework.restdocs.test.ExpectedSnippets;
@@ -226,6 +228,33 @@ public class SectionSnippetTest {
 
         new SectionBuilder()
                 .snippetNames(HTTP_RESPONSE, RESPONSE_FIELDS, HTTP_REQUEST, "my-snippet-name")
+                .build()
+                .document(operationBuilder
+                        .attribute(HandlerMethod.class.getName(), handlerMethod)
+                        .attribute(JavadocReader.class.getName(), javadocReader)
+                        .attribute(ATTRIBUTE_NAME_DEFAULT_SNIPPETS, Arrays.asList(
+                                pathParameters(), requestParameters(),
+                                requestFields(), responseFields(), curlRequest(),
+                                HttpDocumentation.httpRequest(), HttpDocumentation.httpResponse()))
+                        .request("http://localhost/items/1")
+                        .build());
+    }
+
+    @Test
+    public void linkSnippet() throws Exception {
+        HandlerMethod handlerMethod = new HandlerMethod(new TestResource(), "getItemById");
+        mockMethodTitle(TestResource.class, "getItemById", "");
+
+        this.snippets.expect(SECTION)
+                .withContents(equalTo("[[resources-linkSnippet]]\n" +
+                        "=== Get Item By Id\n\n" +
+                        "include::auto-method-path.adoc[]\n\n" +
+                        "include::auto-description.adoc[]\n\n" +
+                        "==== Hypermedia links\n\n" +
+                        "include::links.adoc[]\n"));
+
+        new SectionBuilder()
+                .snippetNames(LINKS)
                 .build()
                 .document(operationBuilder
                         .attribute(HandlerMethod.class.getName(), handlerMethod)

--- a/spring-auto-restdocs-core/src/test/resources/capital/scalable/restdocs/i18n/TestSnippetMessages.properties
+++ b/spring-auto-restdocs-core/src/test/resources/capital/scalable/restdocs/i18n/TestSnippetMessages.properties
@@ -20,3 +20,4 @@ pagination-request-adoc=XSupports standard <<overview-pagination,paging>> query 
 pagination-request-md=XSupports standard [paging](#overview-pagination) query parameters.
 pagination-response-adoc=XStandard <<overview-pagination,paging>> response where `content` field is list of following objects:
 pagination-response-md=XStandard [paging](#overview-pagination) response where `content` field is list of following objects:
+my-snippet-header-key=My snippet


### PR DESCRIPTION
Adds a way to register custom "classic snippet"
Also preregisters "links" as a known classic snippet.

Refer to #248 for more details. 