### PR TITLE
Fixed missing handler method on error (WebTestClient)

### DIFF
--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/webtestclient/WebTestClientInitializer.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/webtestclient/WebTestClientInitializer.java
@@ -31,15 +31,15 @@ import org.springframework.core.Ordered;
 import org.springframework.restdocs.snippet.Snippet;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.reactive.DispatcherHandler;
+import org.springframework.web.reactive.HandlerAdapter;
 import org.springframework.web.reactive.HandlerResult;
-import org.springframework.web.reactive.HandlerResultHandler;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 /**
  * Watches the WebTestClient and applies some attributes on each operation.
  */
-public class WebTestClientInitializer implements HandlerResultHandler, Ordered {
+public class WebTestClientInitializer implements HandlerAdapter, Ordered {
 
     /**
      * The called {@link HandlerMethod}.
@@ -47,18 +47,18 @@ public class WebTestClientInitializer implements HandlerResultHandler, Ordered {
     private HandlerMethod handlerMethod;
 
     @Override
-    public boolean supports(HandlerResult result) {
+    public boolean supports(Object handler) {
         // if a handler method is set: remember it
-        if (result.getHandler() instanceof HandlerMethod) {
-            handlerMethod = (HandlerMethod) result.getHandler();
+        if (handler instanceof HandlerMethod) {
+            handlerMethod = (HandlerMethod) handler;
         }
         // all done - nothing more to do
         return false;
     }
 
     @Override
-    public Mono<Void> handleResult(ServerWebExchange exchange, HandlerResult result) {
-        // nothing to do - handler already registered in #supports(HandlerResult)
+    public Mono<HandlerResult> handle(ServerWebExchange exchange, Object handler) {
+        // nothing to do - handler already registered in #supports(Object)
         return Mono.empty();
     }
 

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/webtestclient/WebTestClientInitializerTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/webtestclient/WebTestClientInitializerTest.java
@@ -50,27 +50,24 @@ import reactor.core.publisher.Mono;
 public class WebTestClientInitializerTest {
 
     /**
-     * Test for method {@link WebTestClientInitializer#supports(HandlerResult)}.
+     * Test for method {@link WebTestClientInitializer#supports(Object)}.
      */
     @Test
     public void supports_withHandlerMethod() {
 
         // prepare:
-        HandlerResult handlerResultMock = mock(HandlerResult.class);
-        HandlerMethod handlerMethodMock = mock(HandlerMethod.class);
-        Mockito.when(handlerResultMock.getHandler()).thenReturn(handlerMethodMock);
+        HandlerMethod handlerMethod = mock(HandlerMethod.class);
 
         // perform:
         WebTestClientInitializer testInstance = new WebTestClientInitializer();
-        boolean result = testInstance.supports(handlerResultMock);
+        boolean result = testInstance.supports(handlerMethod);
 
         // verify:
         assertFalse(result);
-        verify(handlerResultMock, atLeast(1)).getHandler();
     }
 
     /**
-     * Test for method {@link WebTestClientInitializer#supports(HandlerResult)} in the
+     * Test for method {@link WebTestClientInitializer#supports(Object)} in the
      * case that the {@linkplain HandlerResult#getHandler() handler} is no
      * {@link HandlerMethod}.
      */
@@ -79,21 +76,18 @@ public class WebTestClientInitializerTest {
 
         // prepare:
         WebTestClientInitializer testInstance = new WebTestClientInitializer();
-        HandlerResult handlerResultMock = mock(HandlerResult.class);
         String noHandlerMethod = "string value just for unit test";
-        Mockito.when(handlerResultMock.getHandler()).thenReturn(noHandlerMethod);
 
         // perform:
-        boolean result = testInstance.supports(handlerResultMock);
+        boolean result = testInstance.supports(noHandlerMethod);
 
         // verify:
         assertFalse(result);
-        verify(handlerResultMock, atLeast(1)).getHandler();
     }
 
     /**
      * Test for method
-     * {@link WebTestClientInitializer#handleResult(ServerWebExchange, HandlerResult)}.
+     * {@link WebTestClientInitializer#handle(ServerWebExchange, Object)}.
      */
     @Test
     public void handleResult_doNothing() {
@@ -104,7 +98,7 @@ public class WebTestClientInitializerTest {
         HandlerResult handlerResult = mock(HandlerResult.class);
 
         // perform:
-        Mono<Void> result = testInstance.handleResult(exchange, handlerResult);
+        Mono<HandlerResult> result = testInstance.handle(exchange, handlerResult);
 
         // verify:
         assertNull(result.block(Duration.ZERO));
@@ -139,10 +133,8 @@ public class WebTestClientInitializerTest {
         when(contextMock.getBean(eq(DispatcherHandler.class)))
                 .thenReturn(dispatcherHandlerMock);
         WebTestClientInitializer webTestClientInitializer = new WebTestClientInitializer();
-        HandlerResult handlerResultMock = mock(HandlerResult.class);
         HandlerMethod handlerMethodMock = mock(HandlerMethod.class);
-        Mockito.when(handlerResultMock.getHandler()).thenReturn(handlerMethodMock);
-        webTestClientInitializer.supports(handlerResultMock);
+        webTestClientInitializer.supports(handlerMethodMock);
         when(contextMock.getBean(eq(WebTestClientInitializer.class)))
                 .thenReturn(webTestClientInitializer);
         when(contextMock.getBean(eq(ObjectMapper.class)))


### PR DESCRIPTION
The current implementation of `WebTestClientInitializer` only works if the rest endpoint succeeds. In case of an error (for example passing an `String` as `PathVariable` of type `int`) the handler method is not determined correctly and this leads for example to a missing headline in the `auto-section.adoc`.

The reason is that spring webflux `DispatcherHandler` first calls all implementations of `HandlerAdapter` and only if they succeeds the `HandlerResultHandler` implementations (the `WebTestClientInitializer` is one of them) are called (see [`DispatcherHandler.java#L156-L161`](https://github.com/spring-projects/spring-framework/blob/v5.0.2.RELEASE/spring-webflux/src/main/java/org/springframework/web/reactive/DispatcherHandler.java#L156-L161)).

To solve this issue I simply changed the `WebTestClientInitializer` to implement `HandlerAdapter` instead of `HandlerResultHandler`.