### PR TITLE
Migration to new (jdk9+) javadoc api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 sudo: false
 dist: trusty
 jdk:
-- oraclejdk8
+- oraclejdk9
 before_cache:
 - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
 - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,8 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.20.1</version>
+                    <!-- at least 2.21.0 is required for jdk 10: https://issues.apache.org/jira/browse/SUREFIRE-1439 -->
+                    <version>2.21.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.asciidoctor</groupId>

--- a/spring-auto-restdocs-json-doclet/pom.xml
+++ b/spring-auto-restdocs-json-doclet/pom.xml
@@ -16,18 +16,11 @@
     <description>Doclet exporting JavaDoc to JSON for Spring Auto REST Docs</description>
 
     <properties>
-        <java.version>1.7</java.version>
+        <java.version>1.9</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>com.sun</groupId>
-            <artifactId>tools</artifactId>
-            <version>1.4.2</version>
-            <scope>system</scope>
-            <systemPath>${java.home}/../lib/tools.jar</systemPath>
-        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>

--- a/spring-auto-restdocs-json-doclet/src/main/java/capital/scalable/restdocs/jsondoclet/ClassDocumentation.java
+++ b/spring-auto-restdocs-json-doclet/src/main/java/capital/scalable/restdocs/jsondoclet/ClassDocumentation.java
@@ -19,12 +19,14 @@
  */
 package capital.scalable.restdocs.jsondoclet;
 
+import jdk.javadoc.doclet.DocletEnvironment;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.sun.javadoc.ClassDoc;
-import com.sun.javadoc.FieldDoc;
-import com.sun.javadoc.MethodDoc;
+import static capital.scalable.restdocs.jsondoclet.DocletUtils.cleanupDocComment;
 
 public final class ClassDocumentation {
     private String comment = "";
@@ -35,15 +37,21 @@ public final class ClassDocumentation {
         // enforce usage of static factory method
     }
 
-    public static ClassDocumentation fromClassDoc(ClassDoc classDoc) {
+    public static ClassDocumentation fromClassDoc(DocletEnvironment docEnv,
+                                                  Element element) {
         ClassDocumentation cd = new ClassDocumentation();
-        cd.setComment(classDoc.commentText());
-        for (FieldDoc fieldDoc : classDoc.fields(false)) {
-            cd.addField(fieldDoc);
-        }
-        for (MethodDoc methodDoc : classDoc.methods(false)) {
-            cd.addMethod(methodDoc);
-        }
+        cd.setComment(cleanupDocComment(docEnv.getElementUtils().getDocComment(element)));
+
+        element.getEnclosedElements().forEach(fieldOrMethod -> {
+            if (fieldOrMethod.getKind().equals(ElementKind.FIELD)) {
+                cd.addField(docEnv, fieldOrMethod);
+            }
+            else if (fieldOrMethod.getKind().equals(ElementKind.METHOD)
+                    || fieldOrMethod.getKind().equals(ElementKind.CONSTRUCTOR)) {
+                cd.addMethod(docEnv, fieldOrMethod);
+            }
+        });
+
         return cd;
     }
 
@@ -51,11 +59,13 @@ public final class ClassDocumentation {
         this.comment = comment;
     }
 
-    private void addField(FieldDoc fieldDoc) {
-        this.fields.put(fieldDoc.name(), FieldDocumentation.fromFieldDoc(fieldDoc));
+    private void addField(DocletEnvironment docEnv, Element element) {
+        this.fields.put(element.getSimpleName().toString(),
+                FieldDocumentation.fromFieldDoc(docEnv, element));
     }
 
-    private void addMethod(MethodDoc methodDoc) {
-        this.methods.put(methodDoc.name(), MethodDocumentation.fromMethodDoc(methodDoc));
+    private void addMethod(DocletEnvironment docEnv, Element element) {
+        this.methods.put(element.getSimpleName().toString(),
+                MethodDocumentation.fromMethodDoc(docEnv, element));
     }
 }

--- a/spring-auto-restdocs-json-doclet/src/main/java/capital/scalable/restdocs/jsondoclet/DocletUtils.java
+++ b/spring-auto-restdocs-json-doclet/src/main/java/capital/scalable/restdocs/jsondoclet/DocletUtils.java
@@ -19,12 +19,23 @@
  */
 package capital.scalable.restdocs.jsondoclet;
 
+import java.util.Optional;
+
 public class DocletUtils {
     private DocletUtils() {
         // utils
     }
 
+    static String cleanupDocComment(String comment) {
+        return Optional.ofNullable(comment).map(s -> s.replaceAll("[\\r\\n]+\\s*@.*", "").trim()).orElse("");
+    }
+
+    public static String cleanupTagValue(String value) {
+        return value.replaceFirst("\\s*@[^\\s]+\\s+", "").trim();
+    }
+
     public static String cleanupTagName(String name) {
         return name.startsWith("@") ? name.substring(1) : name;
     }
+
 }

--- a/spring-auto-restdocs-json-doclet/src/main/java/capital/scalable/restdocs/jsondoclet/FieldDocumentation.java
+++ b/spring-auto-restdocs-json-doclet/src/main/java/capital/scalable/restdocs/jsondoclet/FieldDocumentation.java
@@ -19,26 +19,32 @@
  */
 package capital.scalable.restdocs.jsondoclet;
 
-import static capital.scalable.restdocs.jsondoclet.DocletUtils.cleanupTagName;
+import com.sun.source.doctree.BlockTagTree;
+import jdk.javadoc.doclet.DocletEnvironment;
 
+import javax.lang.model.element.Element;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
-import com.sun.javadoc.FieldDoc;
-import com.sun.javadoc.Tag;
+import static capital.scalable.restdocs.jsondoclet.DocletUtils.*;
 
 public class FieldDocumentation {
 
     private String comment;
     private final Map<String, String> tags = new HashMap<>();
 
-    public static FieldDocumentation fromFieldDoc(FieldDoc fieldDoc) {
+    public static FieldDocumentation fromFieldDoc(DocletEnvironment docEnv,
+                                                  Element fieldElement) {
         FieldDocumentation fd = new FieldDocumentation();
-        fd.comment = fieldDoc.commentText();
+        fd.comment = cleanupDocComment(docEnv.getElementUtils().getDocComment(fieldElement));
 
-        for (Tag tag : fieldDoc.tags()) {
-            fd.tags.put(cleanupTagName(tag.name()), tag.text());
-        }
+
+        Optional.ofNullable(docEnv.getDocTrees().getDocCommentTree(fieldElement))
+                .ifPresent(docCommentTree -> docCommentTree.getBlockTags()
+                        .forEach(tag -> fd.tags.put(
+                                cleanupTagName(((BlockTagTree) tag).getTagName()),
+                                cleanupTagValue(tag.toString()))));
 
         return fd;
     }


### PR DESCRIPTION
I have migrated the java part (javadoc doclet) to the new (jdk9+) javadoc api.

The new doclet replaces the old one because I haven't found any way to put them together side by side in the same maven project. The new api wasn't there in jdk <= 8 and the old api was removed in jdk >= 10. So I can't see any other solution than putting them into two different branches (like it's done in https://github.com/talsma-ict/umldoclet).

The build of this branch fails because I haven't touched the dokka extension. It seems like the dokka version have to be updated too:
> - Fix Dokka Maven Plugin to work on JDK9 [#272](https://github.com/Kotlin/dokka/issues/272)

But there are also some incompatibilities:

> **Internals**
> 
> LocationService removed, and all logic of path calculations was moved to NodeLocationAwareGenerator which implemented by FileGenerator
>
> FormatDescriptor now can bind its own services, as it has access to output & analysis module Binder
By default, there is a hierarchy of some abstract base format descriptors, which provides an interface of required services

See https://github.com/Kotlin/dokka/releases/tag/0.9.17.

As mentioned in #243 I'm not familiar with kotlin (and dokka). The best solution may be the migration to the new dokka api but I can't found a detailed migration guide to do this without any knowledge of kotlin/dokka. Maybe someone can help to fix this or at least give me some hints?


Closes #243 