### PR TITLE
Ignore properties annotated with JsonIgnore

### DIFF
--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/FieldDocumentationObjectVisitor.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/FieldDocumentationObjectVisitor.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -127,7 +128,8 @@ class FieldDocumentationObjectVisitor extends JsonObjectFormatVisitor.Base {
         Class<?> rawClass = prop.getType().getContentType() != null
                 ? prop.getType().getContentType().getRawClass()
                 : prop.getType().getRawClass();
-        return SKIPPED_FIELDS.contains(prop.getName())
-                || SKIPPED_CLASSES.contains(rawClass.getCanonicalName());
+        JsonIgnore ignoreProperty = prop.getMember().getAnnotation(JsonIgnore.class);
+        return SKIPPED_FIELDS.contains(prop.getName()) || SKIPPED_CLASSES.contains(rawClass.getCanonicalName())
+                || ignoreProperty != null;
     }
 }

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/jackson/FieldDocumentationGeneratorTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/jackson/FieldDocumentationGeneratorTest.java
@@ -479,6 +479,25 @@ public class FieldDocumentationGeneratorTest {
         assertThat(result.get(1), is(descriptor("number", "Integer", "An integer", "false")));
     }
 
+    @Test
+    public void testGenerateDocumentationForIgnoreProperties() throws Exception {
+        // given
+        ObjectMapper mapper = createMapper();
+        mockFieldComment(IgnoreProperties.class, "otherString", "A string");
+
+        FieldDocumentationGenerator generator =
+                new FieldDocumentationGenerator(mapper.writer(), mapper.getDeserializationConfig(),
+                        javadocReader, constraintReader);
+        Type type = IgnoreProperties.class;
+
+        // when
+        List<ExtendedFieldDescriptor> result = cast(generator
+                .generateDocumentation(type, mapper.getTypeFactory()));
+        // then
+        assertThat(result.size(), is(1));
+        assertThat(result.get(0), is(descriptor("string", "String", "A string", "true")));
+    }
+
     private OngoingStubbing<List<String>> mockOptional(Class<?> javaBaseClass, String fieldName,
             String value) {
         return when(constraintReader.getOptionalMessages(javaBaseClass, fieldName))
@@ -722,5 +741,13 @@ public class FieldDocumentationGeneratorTest {
         private String string;
         @JsonProperty(required = true)
         private Integer number;
+    }
+
+    private static class IgnoreProperties {
+        @JsonIgnore
+        private String string;
+        @JsonIgnore
+        private Integer number;
+        private String otherString;
     }
 }

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/jackson/FieldDocumentationGeneratorTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/jackson/FieldDocumentationGeneratorTest.java
@@ -495,7 +495,7 @@ public class FieldDocumentationGeneratorTest {
                 .generateDocumentation(type, mapper.getTypeFactory()));
         // then
         assertThat(result.size(), is(1));
-        assertThat(result.get(0), is(descriptor("string", "String", "A string", "true")));
+        assertThat(result.get(0), is(descriptor("otherString", "String", "A string", "true")));
     }
 
     private OngoingStubbing<List<String>> mockOptional(Class<?> javaBaseClass, String fieldName,


### PR DESCRIPTION
When generating docs, ignore properties annotated with JsonIgnore