### PR TITLE
Switch to Ubuntu Trusty for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: java
 sudo: false
 dist: xenial
 jdk:
-- oraclejdk8
-- oraclejdk7
+- openjdk7
+- openjdk8
 before_cache:
 - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
 - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 sudo: false
-dist: precise
+dist: xenial
 jdk:
 - oraclejdk8
 - oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 sudo: false
-dist: xenial
+dist: trusty
 jdk:
 - openjdk7
 - openjdk8


### PR DESCRIPTION
We are getting a warning on our Travis builds:
```
This job ran on our Precise environment, which is in the process of being decommissioned. Please update to a newer Ubuntu version by specifying dist: xenial in your .travis.yml.
```

Supported distribution: https://docs.travis-ci.com/user/reference/overview/#linux

The latest one is Ubuntu Xenial 16.04, but I don't think that the support Java 7 on it. Ubuntu Trusty 14.04 is still the default and supports openjdk7 and openjdk8. Oracle JDK 7 is not provided because it reached End of Life in April 2015. Seehttps://docs.travis-ci.com/user/reference/trusty/#jvm-clojure-groovy-java-scala-images
