### PR TITLE
Add support for release version of spring hateoas

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ from the Introducing Spring Auto REST Docs talk at Spring IO 2017 are also avail
 
 ## Documentation
 
-[Current 2.0.5 release](https://htmlpreview.github.io/?https://github.com/ScaCap/spring-auto-restdocs/blob/v2.0.5/docs/index.html) reference guide (based on Spring REST Docs 2.x).
+[Current 2.0.6 release](https://htmlpreview.github.io/?https://github.com/ScaCap/spring-auto-restdocs/blob/v2.0.6/docs/index.html) reference guide (based on Spring REST Docs 2.x).
 
 [Current 1.0.15 release](https://htmlpreview.github.io/?https://github.com/ScaCap/spring-auto-restdocs/blob/v1.0.15/docs/index.html) reference guide (based on Spring REST Docs 1.x).
 
-Latest master [2.0.6-SNAPSHOT](https://scacap.github.io/spring-auto-restdocs) reference guide.
+Latest master [2.0.7-SNAPSHOT](https://scacap.github.io/spring-auto-restdocs) reference guide.
 
 Older releases:
-[2.0.4](https://htmlpreview.github.io/?https://github.com/ScaCap/spring-auto-restdocs/blob/v2.0.4/docs/index.html),
+[2.0.5](https://htmlpreview.github.io/?https://github.com/ScaCap/spring-auto-restdocs/blob/v2.0.5/docs/index.html),
 [1.0.14](https://htmlpreview.github.io/?https://github.com/ScaCap/spring-auto-restdocs/blob/v1.0.14/docs/index.html)
 
 ## Main features

--- a/docs/index.html
+++ b/docs/index.html
@@ -437,7 +437,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <h1>Spring Auto REST Docs</h1>
 <div class="details">
 <span id="author" class="author">Scalable Capital</span><br>
-    <span id="revnumber">version 2.0.6</span>
+<span id="revnumber">version 2.0.6</span>
 </div>
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
@@ -653,7 +653,7 @@ please use the 1.0.x version of Spring Auto REST Docs.</p>
 <pre class="highlightjs highlight"><code class="language-xml hljs" data-lang="xml">&lt;dependency&gt;
     &lt;groupId&gt;capital.scalable&lt;/groupId&gt;
     &lt;artifactId&gt;spring-auto-restdocs-core&lt;/artifactId&gt;
-    &lt;version&gt;2.0.5&lt;/version&gt;
+    &lt;version&gt;2.0.6&lt;/version&gt;
     &lt;scope&gt;test&lt;/scope&gt;
 &lt;/dependency&gt;
 
@@ -690,7 +690,7 @@ please use the 1.0.x version of Spring Auto REST Docs.</p>
                         &lt;docletArtifact&gt;
                             &lt;groupId&gt;capital.scalable&lt;/groupId&gt;
                             &lt;artifactId&gt;spring-auto-restdocs-json-doclet&lt;/artifactId&gt; <i class="conum" data-value="3"></i><b>(3)</b>
-                            &lt;version&gt;2.0.5&lt;/version&gt;
+                            &lt;version&gt;2.0.6&lt;/version&gt;
                         &lt;/docletArtifact&gt;
                         &lt;destDir&gt;generated-javadoc-json&lt;/destDir&gt; <i class="conum" data-value="2"></i><b>(2)</b>
                         &lt;reportOutputDirectory&gt;${project.build.directory}&lt;/reportOutputDirectory&gt; <i class="conum" data-value="2"></i><b>(2)</b>
@@ -735,8 +735,8 @@ ext {
 }
 
 dependencies {
-    testCompile group: 'capital.scalable', name: 'spring-auto-restdocs-core', version: '2.0.5'
-    jsondoclet group: 'capital.scalable', name: 'spring-auto-restdocs-json-doclet', version: '2.0.5' <i class="conum" data-value="3"></i><b>(3)</b>
+    testCompile group: 'capital.scalable', name: 'spring-auto-restdocs-core', version: '2.0.6'
+    jsondoclet group: 'capital.scalable', name: 'spring-auto-restdocs-json-doclet', version: '2.0.6' <i class="conum" data-value="3"></i><b>(3)</b>
 }
 
 task jsonDoclet(type: Javadoc, dependsOn: compileJava) {
@@ -2508,8 +2508,8 @@ and has to be installed with the Maven command shown in the section above.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-    Version 2.0.6<br>
-    Last updated 2019-06-11 10:00:22 CEST
+Version 2.0.6<br>
+Last updated 2019-07-18 11:59:24 CEST
 </div>
 </div>
 <link rel="stylesheet" href="highlight/styles/github.min.css">

--- a/docs/index.html
+++ b/docs/index.html
@@ -437,7 +437,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <h1>Spring Auto REST Docs</h1>
 <div class="details">
 <span id="author" class="author">Scalable Capital</span><br>
-<span id="revnumber">version 2.0.5</span>
+    <span id="revnumber">version 2.0.6</span>
 </div>
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
@@ -2508,8 +2508,8 @@ and has to be installed with the Maven command shown in the section above.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version 2.0.5<br>
-Last updated 2019-05-06 09:47:55 CEST
+    Version 2.0.6<br>
+    Last updated 2019-06-11 10:00:22 CEST
 </div>
 </div>
 <link rel="stylesheet" href="highlight/styles/github.min.css">

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>capital.scalable</groupId>
     <artifactId>spring-auto-restdocs-parent</artifactId>
-    <version>2.0.6-SNAPSHOT</version>
+    <version>2.0.6</version>
     <packaging>pom</packaging>
 
     <name>Spring Auto REST Docs Parent POM</name>

--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.9.9</version>
+                <version>2.9.9.1</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>

--- a/samples/java-webflux/generated-docs/index.html
+++ b/samples/java-webflux/generated-docs/index.html
@@ -458,7 +458,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="sect2">
 <h3 id="resources-item-resource-test-get-item"><a class="anchor" href="#resources-item-resource-test-get-item"></a><a class="link" href="#resources-item-resource-test-get-item">1.1. Get Item</a></h3>
 <div class="paragraph">
-<p><code>GET /items/1</code></p>
+  <p><code>+GET /items/1+</code></p>
 </div>
 <div class="paragraph">
 <p>Returns item by ID.</p>
@@ -692,7 +692,7 @@ X-XSS-Protection: 1 ; mode=block
 <div class="sect2">
 <h3 id="resources-item-resource-test-get-all-items"><a class="anchor" href="#resources-item-resource-test-get-all-items"></a><a class="link" href="#resources-item-resource-test-get-all-items">1.2. All Items</a></h3>
 <div class="paragraph">
-<p><code>GET /items</code></p>
+  <p><code>+GET /items+</code></p>
 </div>
 <div class="paragraph">
 <p>Lists all items.</p>
@@ -911,7 +911,7 @@ Content-Length: 598
 <div class="sect2">
 <h3 id="resources-item-resource-test-update-item"><a class="anchor" href="#resources-item-resource-test-update-item"></a><a class="link" href="#resources-item-resource-test-update-item">1.3. Update Item</a></h3>
 <div class="paragraph">
-<p><code>PUT /items/1</code></p>
+  <p><code>+PUT /items/1+</code></p>
 </div>
 <div class="paragraph">
 <p>Updates existing item.</p>
@@ -1166,7 +1166,7 @@ Content-Length: 124
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-03-25 20:17:39 CET
+  Last updated 2019-05-22 09:13:17 CEST
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css">

--- a/samples/java-webflux/pom.xml
+++ b/samples/java-webflux/pom.xml
@@ -35,7 +35,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <start-class>capital.scalable.restdocs.example.Application</start-class>
         <spring-restdocs.version>2.0.3.RELEASE</spring-restdocs.version>
-        <spring-auto-restdocs.version>2.0.6-SNAPSHOT</spring-auto-restdocs.version>
+        <spring-auto-restdocs.version>2.0.6</spring-auto-restdocs.version>
     </properties>
 
     <dependencies>

--- a/samples/java-webmvc/build.gradle
+++ b/samples/java-webmvc/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springAutoRestDocsVersion = "2.0.6-SNAPSHOT"
+        springAutoRestDocsVersion = "2.0.6"
         springRestDocsVersion = "2.0.3.RELEASE"
         springBootVersion = "2.1.5.RELEASE"
     }

--- a/samples/java-webmvc/generated-docs/index.html
+++ b/samples/java-webmvc/generated-docs/index.html
@@ -1105,7 +1105,7 @@ Content-Length: 598
 <div class="sect2">
 <h3 id="resources-item-resource-test-add-item"><a class="anchor" href="#resources-item-resource-test-add-item"></a><a class="link" href="#resources-item-resource-test-add-item">2.3. Add Item</a></h3>
 <div class="paragraph">
-<p><code>POST /items</code></p>
+  <p><code>+POST /items+</code></p>
 </div>
 <div class="paragraph">
 <p>Adds new item.</p>
@@ -1195,7 +1195,7 @@ Size must be between 0 and 1000 inclusive.</p></td>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items' -i -X POST \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer 904105cb-7a6d-4513-ada1-cc27ab84508e' \
+    -H 'Authorization: Bearer 50aabaa0-b7fc-41e9-83fa-e6884fc4f7df' \
     -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
@@ -1219,7 +1219,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate</code></pre>
 <div class="sect2">
 <h3 id="resources-item-resource-test-update-item"><a class="anchor" href="#resources-item-resource-test-update-item"></a><a class="link" href="#resources-item-resource-test-update-item">2.4. Update Item</a></h3>
 <div class="paragraph">
-<p><code>PUT /items/{id}</code></p>
+  <p><code>+PUT /items/{id}+</code></p>
 </div>
 <div class="paragraph">
 <p>Updates existing item.</p>
@@ -1458,7 +1458,7 @@ Must be at most 10.</p></td>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X PUT \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer 904105cb-7a6d-4513-ada1-cc27ab84508e' \
+    -H 'Authorization: Bearer 50aabaa0-b7fc-41e9-83fa-e6884fc4f7df' \
     -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
@@ -1492,7 +1492,7 @@ Content-Length: 124
 <div class="sect2">
 <h3 id="resources-item-resource-test-delete-item"><a class="anchor" href="#resources-item-resource-test-delete-item"></a><a class="link" href="#resources-item-resource-test-delete-item">2.5. Delete Item</a></h3>
 <div class="paragraph">
-<p><code>DELETE /items/{id}</code></p>
+  <p><code>+DELETE /items/{id}+</code></p>
 </div>
 <div class="paragraph">
 <p>Deletes item.<br>
@@ -1576,7 +1576,7 @@ Item must exist.</p>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X DELETE \
-    -H 'Authorization: Bearer 904105cb-7a6d-4513-ada1-cc27ab84508e'</code></pre>
+    -H 'Authorization: Bearer 50aabaa0-b7fc-41e9-83fa-e6884fc4f7df'</code></pre>
 </div>
 </div>
 </div>
@@ -1598,7 +1598,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate</code></pre>
 <div class="sect2">
 <h3 id="resources-item-resource-test-get-child-item"><a class="anchor" href="#resources-item-resource-test-get-child-item"></a><a class="link" href="#resources-item-resource-test-get-child-item">2.6. Get Child</a></h3>
 <div class="paragraph">
-<p><code>GET /items/{id}/{child}</code></p>
+  <p><code>+GET /items/{id}/{child}+</code></p>
 </div>
 <div class="paragraph">
 <p>Retrieves a child of specified item.</p>
@@ -1845,7 +1845,7 @@ Content-Length: 133
 <div class="sect2">
 <h3 id="resources-item-resource-test-search"><a class="anchor" href="#resources-item-resource-test-search"></a><a class="link" href="#resources-item-resource-test-search">2.7. Search Item</a></h3>
 <div class="paragraph">
-<p><code>GET /items/search</code></p>
+  <p><code>+GET /items/search+</code></p>
 </div>
 <div class="paragraph">
 <p>Searches for item based on lookup parameters.</p>
@@ -2147,7 +2147,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 <div class="sect2">
 <h3 id="resources-item-resource-test-process-all-items"><a class="anchor" href="#resources-item-resource-test-process-all-items"></a><a class="link" href="#resources-item-resource-test-process-all-items">2.8. Process All Items</a></h3>
 <div class="paragraph">
-<p><code>POST /items/process</code></p>
+  <p><code>+POST /items/process+</code></p>
 </div>
 <div class="paragraph">
 <p>Executes a command on all items.</p>
@@ -2273,7 +2273,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 <div class="sect2">
 <h3 id="resources-item-resource-test-process-single-item"><a class="anchor" href="#resources-item-resource-test-process-single-item"></a><a class="link" href="#resources-item-resource-test-process-single-item">2.9. Process One Item</a></h3>
 <div class="paragraph">
-<p><code>POST /items/{itemId}/process</code></p>
+  <p><code>+POST /items/{itemId}/process+</code></p>
 </div>
 <div class="paragraph">
 <p>Executes a command on an item.<br>
@@ -2434,7 +2434,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 <div class="sect2">
 <h3 id="resources-item-resource-test-validate-metadata"><a class="anchor" href="#resources-item-resource-test-validate-metadata"></a><a class="link" href="#resources-item-resource-test-validate-metadata">2.10. Validate Metadata</a></h3>
 <div class="paragraph">
-<p><code>POST /items/validateMetadata</code></p>
+  <p><code>+POST /items/validateMetadata+</code></p>
 </div>
 <div class="paragraph">
 <p>Validates metadata.</p>
@@ -2559,7 +2559,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate</code></pre>
 <div class="sect2">
 <h3 id="resources-item-resource-test-clone-item"><a class="anchor" href="#resources-item-resource-test-clone-item"></a><a class="link" href="#resources-item-resource-test-clone-item">2.11. Clone Item (deprecated)</a></h3>
 <div class="paragraph">
-<p><code>POST /items/cloneItem</code></p>
+  <p><code>+POST /items/cloneItem+</code></p>
 </div>
 <div class="paragraph">
 <p><strong>Deprecated.</strong> Create a new item instead.</p>
@@ -2662,7 +2662,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate</code></pre>
 <div class="sect2">
 <h3 id="resources-item-resource-test-get-item-as-resource"><a class="anchor" href="#resources-item-resource-test-get-item-as-resource"></a><a class="link" href="#resources-item-resource-test-get-item-as-resource">2.12. Get Hypermedia Item</a></h3>
 <div class="paragraph">
-<p><code>GET /items/media/{id}</code></p>
+  <p><code>+GET /items/media/{id}+</code></p>
 </div>
 <div class="paragraph">
 <p>Returns item with hypermedia.</p>
@@ -2922,7 +2922,7 @@ All is configured together to compose a convenient section snippet.</p>
 <div class="sect2">
 <h3 id="resources-item-resource-test-get-item-with-rest-docs"><a class="anchor" href="#resources-item-resource-test-get-item-with-rest-docs"></a><a class="link" href="#resources-item-resource-test-get-item-with-rest-docs">3.1. Get Item</a></h3>
 <div class="paragraph">
-<p><code>GET /items/{id}</code></p>
+  <p><code>+GET /items/{id}+</code></p>
 </div>
 <div class="paragraph">
 <p>Returns item by ID.</p>
@@ -3050,7 +3050,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2018-04-10 10:14:19 CEST
+  Last updated 2019-05-22 09:13:17 CEST
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css">

--- a/samples/java-webmvc/pom.xml
+++ b/samples/java-webmvc/pom.xml
@@ -35,7 +35,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <start-class>capital.scalable.restdocs.example.Application</start-class>
         <spring-restdocs.version>2.0.3.RELEASE</spring-restdocs.version>
-        <spring-auto-restdocs.version>2.0.6-SNAPSHOT</spring-auto-restdocs.version>
+        <spring-auto-restdocs.version>2.0.6</spring-auto-restdocs.version>
     </properties>
 
     <dependencies>

--- a/samples/kotlin-webmvc/build.gradle
+++ b/samples/kotlin-webmvc/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         kotlinVersion = "1.3.21"
-        springAutoRestDocsVersion = "2.0.6-SNAPSHOT"
+        springAutoRestDocsVersion = "2.0.6"
         springRestDocsVersion = "2.0.3.RELEASE"
         springBootVersion = "2.1.5.RELEASE"
         dokkaVersion = "0.9.18"

--- a/samples/kotlin-webmvc/generated-docs/index.html
+++ b/samples/kotlin-webmvc/generated-docs/index.html
@@ -1070,7 +1070,7 @@ Content-Length: 598
 <div class="sect2">
 <h3 id="resources-item-resource-test-add-item"><a class="anchor" href="#resources-item-resource-test-add-item"></a><a class="link" href="#resources-item-resource-test-add-item">2.3. Add Item</a></h3>
 <div class="paragraph">
-<p><code>POST /items</code></p>
+  <p><code>+POST /items+</code></p>
 </div>
 <div class="paragraph">
 <p>Adds new item.</p>
@@ -1146,7 +1146,7 @@ Size must be between 0 and 1000 inclusive.</p></td>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items' -i -X POST \
-    -H 'Authorization: Bearer 73c2231c-2c16-4523-8160-ef14f96cc797' \
+    -H 'Authorization: Bearer 33fa9496-4707-4234-ace8-14c12c202c2d' \
     -H 'Content-Type: application/json' \
     -d '{"description":"Hot News"}'</code></pre>
 </div>
@@ -1171,7 +1171,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate</code></pre>
 <div class="sect2">
 <h3 id="resources-item-resource-test-update-item"><a class="anchor" href="#resources-item-resource-test-update-item"></a><a class="link" href="#resources-item-resource-test-update-item">2.4. Update Item</a></h3>
 <div class="paragraph">
-<p><code>PUT /items/{id}</code></p>
+  <p><code>+PUT /items/{id}+</code></p>
 </div>
 <div class="paragraph">
 <p>Updates existing item.</p>
@@ -1389,7 +1389,7 @@ Must be at most 10.</p></td>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X PUT \
-    -H 'Authorization: Bearer 73c2231c-2c16-4523-8160-ef14f96cc797' \
+    -H 'Authorization: Bearer 33fa9496-4707-4234-ace8-14c12c202c2d' \
     -H 'Content-Type: application/json' \
     -d '{"description":"Hot News"}'</code></pre>
 </div>
@@ -1424,7 +1424,7 @@ Content-Length: 124
 <div class="sect2">
 <h3 id="resources-item-resource-test-delete-item"><a class="anchor" href="#resources-item-resource-test-delete-item"></a><a class="link" href="#resources-item-resource-test-delete-item">2.5. Delete Item</a></h3>
 <div class="paragraph">
-<p><code>DELETE /items/{id}</code></p>
+  <p><code>+DELETE /items/{id}+</code></p>
 </div>
 <div class="paragraph">
 <p>Deletes item.Item must exist.</p>
@@ -1492,7 +1492,7 @@ Content-Length: 124
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X DELETE \
-    -H 'Authorization: Bearer 73c2231c-2c16-4523-8160-ef14f96cc797'</code></pre>
+    -H 'Authorization: Bearer 33fa9496-4707-4234-ace8-14c12c202c2d'</code></pre>
 </div>
 </div>
 </div>
@@ -1514,7 +1514,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate</code></pre>
 <div class="sect2">
 <h3 id="resources-item-resource-test-get-child-item"><a class="anchor" href="#resources-item-resource-test-get-child-item"></a><a class="link" href="#resources-item-resource-test-get-child-item">2.6. Get Child</a></h3>
 <div class="paragraph">
-<p><code>GET /items/{id}/{child}</code></p>
+  <p><code>+GET /items/{id}/{child}+</code></p>
 </div>
 <div class="paragraph">
 <p>Retrieves a child of specified item.</p>
@@ -1739,7 +1739,7 @@ Content-Length: 133
 <div class="sect2">
 <h3 id="resources-item-resource-test-search"><a class="anchor" href="#resources-item-resource-test-search"></a><a class="link" href="#resources-item-resource-test-search">2.7. Search Item</a></h3>
 <div class="paragraph">
-<p><code>GET /items/search</code></p>
+  <p><code>+GET /items/search+</code></p>
 </div>
 <div class="paragraph">
 <p>Searches for item based on lookup parameters.</p>
@@ -2002,8 +2002,8 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
   "totalElements" : 1,
   "size" : 20,
   "number" : 0,
-  "first" : true,
   "numberOfElements" : 1,
+  "first" : true,
   "sort" : {
     "orders" : [ ],
     "sorted" : false,
@@ -2019,7 +2019,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 <div class="sect2">
 <h3 id="resources-item-resource-test-process-all-items"><a class="anchor" href="#resources-item-resource-test-process-all-items"></a><a class="link" href="#resources-item-resource-test-process-all-items">2.8. Process All Items</a></h3>
 <div class="paragraph">
-<p><code>POST /items/process</code></p>
+  <p><code>+POST /items/process+</code></p>
 </div>
 <div class="paragraph">
 <p>Executes a command on all items.</p>
@@ -2133,7 +2133,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 <div class="sect2">
 <h3 id="resources-item-resource-test-process-single-item"><a class="anchor" href="#resources-item-resource-test-process-single-item"></a><a class="link" href="#resources-item-resource-test-process-single-item">2.9. Process One Item</a></h3>
 <div class="paragraph">
-<p><code>POST /items/{itemId}/process</code></p>
+  <p><code>+POST /items/{itemId}/process+</code></p>
 </div>
 <div class="paragraph">
 <p>Executes a command on an item.This endpoint demos the basic support for @ModelAttribute.</p>
@@ -2281,7 +2281,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 <div class="sect2">
 <h3 id="resources-item-resource-test-validate-metadata"><a class="anchor" href="#resources-item-resource-test-validate-metadata"></a><a class="link" href="#resources-item-resource-test-validate-metadata">2.10. Validate Metadata</a></h3>
 <div class="paragraph">
-<p><code>POST /items/validateMetadata</code></p>
+  <p><code>+POST /items/validateMetadata+</code></p>
 </div>
 <div class="paragraph">
 <p>Validates metadata.</p>
@@ -2386,7 +2386,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate</code></pre>
 <div class="sect2">
 <h3 id="resources-item-resource-test-clone-item"><a class="anchor" href="#resources-item-resource-test-clone-item"></a><a class="link" href="#resources-item-resource-test-clone-item">2.11. Clone Item</a></h3>
 <div class="paragraph">
-<p><code>POST /items/cloneItem</code></p>
+  <p><code>+POST /items/cloneItem+</code></p>
 </div>
 <div class="paragraph">
 <p>Clones an item.</p>
@@ -2586,7 +2586,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2018-04-10 10:14:19 CEST
+  Last updated 2019-05-22 09:13:17 CEST
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css">

--- a/samples/kotlin-webmvc/pom.xml
+++ b/samples/kotlin-webmvc/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring-restdocs.version>2.0.3.RELEASE</spring-restdocs.version>
-        <spring-auto-restdocs.version>2.0.6-SNAPSHOT</spring-auto-restdocs.version>
+        <spring-auto-restdocs.version>2.0.6</spring-auto-restdocs.version>
         <kotlin.version>1.3.21</kotlin.version>
         <dokka.version>0.9.18</dokka.version>
         <jsonDirectory>${project.build.directory}/generated-javadoc-json</jsonDirectory>

--- a/samples/shared/pom.xml
+++ b/samples/shared/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring-auto-restdocs.version>2.0.6-SNAPSHOT</spring-auto-restdocs.version>
+        <spring-auto-restdocs.version>2.0.6</spring-auto-restdocs.version>
     </properties>
 
     <dependencies>

--- a/samples/shared/pom.xml
+++ b/samples/shared/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.9</version>
+            <version>2.9.9.1</version>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>

--- a/spring-auto-restdocs-annotations/pom.xml
+++ b/spring-auto-restdocs-annotations/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>capital.scalable</groupId>
         <artifactId>spring-auto-restdocs-parent</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.6</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/spring-auto-restdocs-core/pom.xml
+++ b/spring-auto-restdocs-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>capital.scalable</groupId>
         <artifactId>spring-auto-restdocs-parent</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.6</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/spring-auto-restdocs-docs/pom.xml
+++ b/spring-auto-restdocs-docs/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>capital.scalable</groupId>
         <artifactId>spring-auto-restdocs-parent</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.6</version>
         <relativePath>..</relativePath>
     </parent>
 
@@ -18,7 +18,7 @@
 
     <properties>
         <docs.dir>${project.basedir}/../docs</docs.dir>
-        <latestRelease>2.0.5</latestRelease> <!-- change this when releasing 2.0.6-SNAPSHOT -->
+        <latestRelease>2.0.6</latestRelease> <!-- change this when releasing 2.0.7-SNAPSHOT -->
     </properties>
 
     <build>

--- a/spring-auto-restdocs-dokka-json/pom.xml
+++ b/spring-auto-restdocs-dokka-json/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>capital.scalable</groupId>
         <artifactId>spring-auto-restdocs-parent</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.6</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/spring-auto-restdocs-json-doclet-jdk9/pom.xml
+++ b/spring-auto-restdocs-json-doclet-jdk9/pom.xml
@@ -5,12 +5,11 @@
     <parent>
         <groupId>capital.scalable</groupId>
         <artifactId>spring-auto-restdocs-parent</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.6</version>
         <relativePath>..</relativePath>
     </parent>
 
     <artifactId>spring-auto-restdocs-json-doclet-jdk9</artifactId>
-    <version>2.0.6-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Spring Auto REST Docs Json Doclet for JDK9+</name>

--- a/spring-auto-restdocs-json-doclet/pom.xml
+++ b/spring-auto-restdocs-json-doclet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>capital.scalable</groupId>
         <artifactId>spring-auto-restdocs-parent</artifactId>
-        <version>2.0.6-SNAPSHOT</version>
+        <version>2.0.6</version>
         <relativePath>..</relativePath>
     </parent>
 


### PR DESCRIPTION
Spring hateoas is currently being prepared for v1.0.0 release.

The 1.0.0m1 version introduced a terminology refactor which affects the class names and packages used by this project.
https://spring.io/blog/2019/03/05/spring-hateoas-1-0-m1-released#overhaul


This change adds support for the new version of hateoas.

- Resources -> CollectionModel
- ...hateoas.core... -> ...hateoas.server.core....
- List\<Link> -> Links

I also add support for PagedModel return type, which is identical to Page.

