### PR TITLE
Fix interpretation of + by not using compat mode

### DIFF
--- a/samples/java-webflux/src/main/asciidoc/index.adoc
+++ b/samples/java-webflux/src/main/asciidoc/index.adoc
@@ -1,6 +1,5 @@
 = Java WebTestClient Example API Documentation
 :doctype: book
-:compat-mode:
 :page-layout!:
 :toc: right
 :toclevels: 2

--- a/samples/java-webmvc/src/main/asciidoc/index.adoc
+++ b/samples/java-webmvc/src/main/asciidoc/index.adoc
@@ -1,6 +1,5 @@
 = Java Web MVC Example API Documentation
 :doctype: book
-:compat-mode:
 :page-layout!:
 :toc: right
 :toclevels: 2

--- a/samples/kotlin-webmvc/src/main/asciidoc/index.adoc
+++ b/samples/kotlin-webmvc/src/main/asciidoc/index.adoc
@@ -1,6 +1,5 @@
 = Kotlin Web MVC Example API Documentation
 :doctype: book
-:compat-mode:
 :page-layout!:
 :toc: right
 :toclevels: 2


### PR DESCRIPTION
The meaning of `+` changed with AsciiDoctor 1.5.0, see https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#formatted-text The compat mode is there to keep the pre 1.5.0 handling, see https://asciidoctor.org/docs/migration/#compat-mode The PR https://github.com/ScaCap/spring-auto-restdocs/pull/327 introduced `+` to disable interpolation, Spring REST Docs is using it and most users will also go with the latest AsciiDoctor version. Thus we should avoid the compat mode.