### PR TITLE
Try to add spring HATEOAS resource

### DIFF
--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippet.java
@@ -37,6 +37,8 @@ public class JacksonResponseFieldSnippet extends AbstractJacksonFieldSnippet {
     public static final String SPRING_DATA_PAGE_CLASS = "org.springframework.data.domain.Page";
     public static final String REACTOR_MONO_CLASS = "reactor.core.publisher.Mono";
     public static final String REACTOR_FLUX_CLASS = "reactor.core.publisher.Flux";
+    public static final String SPRING_HATEOAS_RESOURCE = "org.springframework.hateoas.Resource";
+    
 
     private final Type responseBodyType;
     private final boolean failOnUndocumentedFields;
@@ -69,6 +71,8 @@ public class JacksonResponseFieldSnippet extends AbstractJacksonFieldSnippet {
         if (HttpEntity.class.isAssignableFrom(returnType)) {
             return firstGenericType(method.getReturnType());
         } else if (SPRING_DATA_PAGE_CLASS.equals(returnType.getCanonicalName())) {
+            return firstGenericType(method.getReturnType());
+        } else if (SPRING_HATEOAS_RESOURCE.equals(returnType.getCanonicalName())) {
             return firstGenericType(method.getReturnType());
         } else if (isCollection(returnType)) {
             return (GenericArrayType) () -> firstGenericType(method.getReturnType());


### PR DESCRIPTION
Hi in my resource setup i do the following wit spring HATEOAS

```
   @GetMapping("contact-point")
    public Resource<RegistrationContactPointJson> setContactPoint() throws CommandHandlingException {
        return new Resource<>(new RegistrationContactPointJson(),
                linkTo(methodOn(SettingsController.class).setContactPoint()).withRel("self"));
```
unfortunately this isn't recognized for the return type

I tried to fix this in the JacksonResponseFieldSnippet. Response filed do work, but links snipped still needs to be fixed. Also I wasn't able to provide a test for the change. Maybe someone can give me a hint, how to do it?

Would be nice, if you would consider to look into the problem :-) 