### PR TITLE
Better support for ModelAttribute

### DIFF
--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/AutoDocumentation.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/AutoDocumentation.java
@@ -24,13 +24,18 @@ import capital.scalable.restdocs.hypermedia.LinksSnippet;
 import capital.scalable.restdocs.misc.AuthorizationSnippet;
 import capital.scalable.restdocs.misc.DescriptionSnippet;
 import capital.scalable.restdocs.misc.MethodAndPathSnippet;
+import capital.scalable.restdocs.payload.JacksonModelAttributeSnippet;
 import capital.scalable.restdocs.payload.JacksonRequestFieldSnippet;
 import capital.scalable.restdocs.payload.JacksonResponseFieldSnippet;
 import capital.scalable.restdocs.request.PathParametersSnippet;
 import capital.scalable.restdocs.request.RequestHeaderSnippet;
 import capital.scalable.restdocs.request.RequestParametersSnippet;
 import capital.scalable.restdocs.section.SectionBuilder;
+
+import java.util.Collection;
+
 import org.springframework.restdocs.snippet.Snippet;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 
 public abstract class AutoDocumentation {
 
@@ -39,6 +44,10 @@ public abstract class AutoDocumentation {
 
     public static JacksonRequestFieldSnippet requestFields() {
         return new JacksonRequestFieldSnippet();
+    }
+
+    public static JacksonModelAttributeSnippet modelAttribute(Collection<HandlerMethodArgumentResolver> handlerMethodArgumentResolvers) {
+        return new JacksonModelAttributeSnippet(handlerMethodArgumentResolvers, false);
     }
 
     public static JacksonResponseFieldSnippet responseFields() {

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/SnippetRegistry.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/SnippetRegistry.java
@@ -33,6 +33,7 @@ public class SnippetRegistry {
     public static final String AUTO_PATH_PARAMETERS = "auto-path-parameters";
     public static final String AUTO_REQUEST_HEADERS = "auto-request-headers";
     public static final String AUTO_REQUEST_PARAMETERS = "auto-request-parameters";
+    public static final String AUTO_MODELATTRIBUTE = "auto-modelattribute";
     public static final String AUTO_REQUEST_FIELDS = "auto-request-fields";
     public static final String AUTO_RESPONSE_FIELDS = "auto-response-fields";
     public static final String AUTO_LINKS = "auto-links";
@@ -101,7 +102,7 @@ public class SnippetRegistry {
         }
 
         @Override
-        public String getHeaderKey() {
+        public String getHeaderKey(Operation operation) {
             return headerKey;
         }
 

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/hypermedia/EmbeddedSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/hypermedia/EmbeddedSnippet.java
@@ -24,6 +24,8 @@ import static capital.scalable.restdocs.SnippetRegistry.AUTO_EMBEDDED;
 import java.lang.reflect.Type;
 
 import capital.scalable.restdocs.payload.AbstractJacksonFieldSnippet;
+
+import org.springframework.restdocs.operation.Operation;
 import org.springframework.web.method.HandlerMethod;
 
 public class EmbeddedSnippet extends AbstractJacksonFieldSnippet {
@@ -55,7 +57,7 @@ public class EmbeddedSnippet extends AbstractJacksonFieldSnippet {
     }
 
     @Override
-    public String getHeaderKey() {
+    public String getHeaderKey(Operation operation) {
         return "embedded";
     }
 

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/hypermedia/LinksSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/hypermedia/LinksSnippet.java
@@ -24,6 +24,7 @@ import static capital.scalable.restdocs.SnippetRegistry.AUTO_LINKS;
 import java.lang.reflect.Type;
 
 import capital.scalable.restdocs.payload.AbstractJacksonFieldSnippet;
+import org.springframework.restdocs.operation.Operation;
 import org.springframework.web.method.HandlerMethod;
 
 public class LinksSnippet extends AbstractJacksonFieldSnippet {
@@ -54,7 +55,7 @@ public class LinksSnippet extends AbstractJacksonFieldSnippet {
     }
 
     @Override
-    public String getHeaderKey() {
+    public String getHeaderKey(Operation operation) {
         return "hypermedia-links";
     }
 

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/misc/AuthorizationSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/misc/AuthorizationSnippet.java
@@ -68,7 +68,7 @@ public class AuthorizationSnippet extends TemplatedSnippet implements SectionSup
     }
 
     @Override
-    public String getHeaderKey() {
+    public String getHeaderKey(Operation operation) {
         return "authorization";
     }
 

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/AbstractJacksonFieldSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/AbstractJacksonFieldSnippet.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -80,7 +80,7 @@ public abstract class AbstractJacksonFieldSnippet extends StandardTableSnippet i
                     javadocReader, constraintReader, typeMapping, translationResolver);
 
             if (shouldFailOnUndocumentedFields()) {
-                assertAllDocumented(fieldDescriptors.values(), translationResolver.translate(getHeaderKey()).toLowerCase());
+                assertAllDocumented(fieldDescriptors.values(), translationResolver.translate(getHeaderKey(operation)).toLowerCase());
             }
             return fieldDescriptors;
         } catch (JsonMappingException e) {
@@ -101,7 +101,7 @@ public abstract class AbstractJacksonFieldSnippet extends StandardTableSnippet i
             } else if (actualArgument instanceof TypeVariable) {
                 TypeVariable typeVariable = (TypeVariable)actualArgument;
                 return findTypeFromTypeVariable(typeVariable, param.getContainingClass());
-            }             
+            }
             return ((ParameterizedType) type).getActualTypeArguments()[0];
         } else {
             return Object.class;
@@ -145,5 +145,18 @@ public abstract class AbstractJacksonFieldSnippet extends StandardTableSnippet i
     @Override
     public boolean hasContent(Operation operation) {
         return getType(getHandlerMethod(operation)) != null;
+    }
+
+    @Override
+    protected String[] getTranslationKeys() {
+        return new String[]{
+            "th-parameter",
+            "th-type",
+            "th-optional",
+            "th-description",
+            "pagination-request-adoc",
+            "pagination-request-md",
+            "no-params"
+        };
     }
 }

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/AbstractJacksonFieldSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/AbstractJacksonFieldSnippet.java
@@ -146,17 +146,4 @@ public abstract class AbstractJacksonFieldSnippet extends StandardTableSnippet i
     public boolean hasContent(Operation operation) {
         return getType(getHandlerMethod(operation)) != null;
     }
-
-    @Override
-    protected String[] getTranslationKeys() {
-        return new String[]{
-            "th-parameter",
-            "th-type",
-            "th-optional",
-            "th-description",
-            "pagination-request-adoc",
-            "pagination-request-md",
-            "no-params"
-        };
-    }
 }

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonModelAttributeSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonModelAttributeSnippet.java
@@ -78,7 +78,7 @@ public class JacksonModelAttributeSnippet extends AbstractJacksonFieldSnippet {
             &&  this.handlerMethodArgumentResolvers != null
             && this.handlerMethodArgumentResolvers
             .stream()
-            .allMatch(obj -> !obj.supportsParameter(param));
+            .noneMatch(obj -> obj.supportsParameter(param));
     }
 
 

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonModelAttributeSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonModelAttributeSnippet.java
@@ -1,0 +1,130 @@
+/*-
+ * #%L
+ * Spring Auto REST Docs Core
+ * %%
+ * Copyright (C) 2015 - 2020 Scalable Capital GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package capital.scalable.restdocs.payload;
+
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.restdocs.operation.Operation;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+
+import capital.scalable.restdocs.OperationAttributeHelper;
+import capital.scalable.restdocs.i18n.SnippetTranslationResolver;
+import capital.scalable.restdocs.jackson.FieldDescriptors;
+import capital.scalable.restdocs.payload.AbstractJacksonFieldSnippet;
+import capital.scalable.restdocs.request.RequestParametersSnippet;
+import capital.scalable.restdocs.util.HandlerMethodUtil;
+
+import static capital.scalable.restdocs.SnippetRegistry.AUTO_MODELATTRIBUTE;
+
+public class JacksonModelAttributeSnippet extends AbstractJacksonFieldSnippet {
+    private final boolean failOnUndocumentedFields;
+    private final Collection<HandlerMethodArgumentResolver> handlerMethodArgumentResolvers;
+
+    public JacksonModelAttributeSnippet() {
+        this(null, false);
+    }
+
+    public JacksonModelAttributeSnippet(Collection<HandlerMethodArgumentResolver> handlerMethodArgumentResolvers, boolean failOnUndocumentedFields) {
+        super(AUTO_MODELATTRIBUTE, null);
+        this.failOnUndocumentedFields = failOnUndocumentedFields;
+        this.handlerMethodArgumentResolvers = handlerMethodArgumentResolvers;
+    }
+
+    @Override
+    protected Type getType(HandlerMethod method) {
+        for (MethodParameter param : method.getMethodParameters()) {
+            if (isModelAttribute(param) || hasNoHandlerMethodArgumentResolver(param)) {
+                return getType(param);
+            }
+        }
+        return null;
+    }
+
+
+    private boolean isModelAttribute(MethodParameter param) {
+        return param.getParameterAnnotation(ModelAttribute.class) != null;
+    }
+
+    private boolean hasNoHandlerMethodArgumentResolver(MethodParameter param) {
+        if(this.handlerMethodArgumentResolvers != null){
+            return this.handlerMethodArgumentResolvers
+            .stream()
+            .allMatch(obj -> !obj.supportsParameter(param));
+        }
+        return false;
+    }
+
+
+    private Type getType(final MethodParameter param) {
+        if (isCollection(param.getParameterType())) {
+            return (GenericArrayType) () -> firstGenericType(param);
+        } else {
+            return param.getParameterType();
+        }
+    }
+
+    /**
+     * is request method get supported
+     * @param method
+     * @return
+     */
+    protected boolean isRequestMethodGet(HandlerMethod method) {
+        RequestMapping requestMapping = method.getMethodAnnotation(RequestMapping.class);
+        return requestMapping == null
+        || requestMapping.method() == null
+        || Arrays.stream(requestMapping.method()).anyMatch(requestMethod -> {
+            return requestMethod == RequestMethod.GET;
+        });
+    }
+
+    @Override
+    protected void enrichModel(Map<String, Object> model, HandlerMethod handlerMethod,
+            FieldDescriptors fieldDescriptors, SnippetTranslationResolver translationResolver) {
+        boolean isPageRequest = HandlerMethodUtil.isPageRequest(handlerMethod);
+        model.put("isPageRequest", isPageRequest);
+        if (isPageRequest) {
+            model.put("noContent", false);
+        }
+    }
+
+    @Override
+    protected boolean shouldFailOnUndocumentedFields() {
+        return failOnUndocumentedFields;
+    }
+
+    @Override
+    public String getHeaderKey(Operation operation) {
+        HandlerMethod method = OperationAttributeHelper.getHandlerMethod(operation);
+        if (method != null && this.isRequestMethodGet(method)) {
+            return "request-parameters";
+        }
+        return "request-fields";
+    }
+}

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonModelAttributeSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonModelAttributeSnippet.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 
+import org.springframework.beans.BeanUtils;
 import org.springframework.core.MethodParameter;
 import org.springframework.restdocs.operation.Operation;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -73,12 +74,11 @@ public class JacksonModelAttributeSnippet extends AbstractJacksonFieldSnippet {
     }
 
     private boolean hasNoHandlerMethodArgumentResolver(MethodParameter param) {
-        if(this.handlerMethodArgumentResolvers != null){
-            return this.handlerMethodArgumentResolvers
+        return !BeanUtils.isSimpleProperty(param.getParameterType())
+            &&  this.handlerMethodArgumentResolvers != null
+            && this.handlerMethodArgumentResolvers
             .stream()
             .allMatch(obj -> !obj.supportsParameter(param));
-        }
-        return false;
     }
 
 

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonModelAttributeSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonModelAttributeSnippet.java
@@ -127,4 +127,17 @@ public class JacksonModelAttributeSnippet extends AbstractJacksonFieldSnippet {
         }
         return "request-fields";
     }
+
+    @Override
+    protected String[] getTranslationKeys() {
+        return new String[]{
+            "th-parameter",
+            "th-type",
+            "th-optional",
+            "th-description",
+            "pagination-request-adoc",
+            "pagination-request-md",
+            "no-params"
+        };
+    }
 }

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonRequestFieldSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonRequestFieldSnippet.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,7 +25,7 @@ import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Type;
 
 import org.springframework.core.MethodParameter;
-import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.restdocs.operation.Operation;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.method.HandlerMethod;
 
@@ -59,7 +59,7 @@ public class JacksonRequestFieldSnippet extends AbstractJacksonFieldSnippet {
         }
 
         for (MethodParameter param : method.getMethodParameters()) {
-            if (isRequestBody(param) || isModelAttribute(param)) {
+            if (isRequestBody(param)) {
                 return getType(param);
             }
         }
@@ -68,10 +68,6 @@ public class JacksonRequestFieldSnippet extends AbstractJacksonFieldSnippet {
 
     private boolean isRequestBody(MethodParameter param) {
         return param.getParameterAnnotation(RequestBody.class) != null;
-    }
-
-    private boolean isModelAttribute(MethodParameter param) {
-        return param.getParameterAnnotation(ModelAttribute.class) != null;
     }
 
     private Type getType(final MethodParameter param) {
@@ -83,7 +79,7 @@ public class JacksonRequestFieldSnippet extends AbstractJacksonFieldSnippet {
     }
 
     @Override
-    public String getHeaderKey() {
+    public String getHeaderKey(Operation operation) {
         return "request-fields";
     }
 

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippet.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import capital.scalable.restdocs.i18n.SnippetTranslationResolver;
 import capital.scalable.restdocs.jackson.FieldDescriptors;
 import org.springframework.http.HttpEntity;
+import org.springframework.restdocs.operation.Operation;
 import org.springframework.web.method.HandlerMethod;
 
 public class JacksonResponseFieldSnippet extends AbstractJacksonFieldSnippet {
@@ -118,7 +119,7 @@ public class JacksonResponseFieldSnippet extends AbstractJacksonFieldSnippet {
     }
 
     @Override
-    public String getHeaderKey() {
+    public String getHeaderKey(Operation operation) {
         return "response-fields";
     }
 

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/AbstractParameterSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/AbstractParameterSnippet.java
@@ -74,7 +74,7 @@ abstract class AbstractParameterSnippet<A extends Annotation> extends StandardTa
         }
 
         if (shouldFailOnUndocumentedParams()) {
-            assertAllDocumented(fieldDescriptors.values(), translationResolver.translate(getHeaderKey()).toLowerCase());
+            assertAllDocumented(fieldDescriptors.values(), translationResolver.translate(getHeaderKey(operation)).toLowerCase());
         }
 
         return fieldDescriptors;

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/PathParametersSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/PathParametersSnippet.java
@@ -22,6 +22,7 @@ package capital.scalable.restdocs.request;
 import static capital.scalable.restdocs.SnippetRegistry.AUTO_PATH_PARAMETERS;
 
 import org.springframework.core.MethodParameter;
+import org.springframework.restdocs.operation.Operation;
 import org.springframework.web.bind.annotation.PathVariable;
 
 public class PathParametersSnippet extends AbstractParameterSnippet<PathVariable> {
@@ -59,7 +60,7 @@ public class PathParametersSnippet extends AbstractParameterSnippet<PathVariable
     }
 
     @Override
-    public String getHeaderKey() {
+    public String getHeaderKey(Operation operation) {
         return "path-parameters";
     }
 

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/RequestHeaderSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/RequestHeaderSnippet.java
@@ -22,6 +22,7 @@ package capital.scalable.restdocs.request;
 import static capital.scalable.restdocs.SnippetRegistry.AUTO_REQUEST_HEADERS;
 
 import org.springframework.core.MethodParameter;
+import org.springframework.restdocs.operation.Operation;
 import org.springframework.web.bind.annotation.RequestHeader;
 
 public class RequestHeaderSnippet extends AbstractParameterSnippet<RequestHeader> {
@@ -59,7 +60,7 @@ public class RequestHeaderSnippet extends AbstractParameterSnippet<RequestHeader
     }
 
     @Override
-    public String getHeaderKey() {
+    public String getHeaderKey(Operation operation) {
         return "request-headers";
     }
 

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/RequestParametersSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/request/RequestParametersSnippet.java
@@ -25,15 +25,16 @@ import java.util.Map;
 
 import capital.scalable.restdocs.i18n.SnippetTranslationResolver;
 import capital.scalable.restdocs.jackson.FieldDescriptors;
+import capital.scalable.restdocs.util.HandlerMethodUtil;
+
 import org.springframework.core.MethodParameter;
+import org.springframework.restdocs.operation.Operation;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ValueConstants;
 import org.springframework.web.method.HandlerMethod;
 
 public class RequestParametersSnippet extends AbstractParameterSnippet<RequestParam> {
 
-    public static final String SPRING_DATA_PAGEABLE_CLASS =
-            "org.springframework.data.domain.Pageable";
 
     private final boolean failOnUndocumentedParams;
 
@@ -82,29 +83,15 @@ public class RequestParametersSnippet extends AbstractParameterSnippet<RequestPa
     @Override
     protected void enrichModel(Map<String, Object> model, HandlerMethod handlerMethod,
             FieldDescriptors fieldDescriptors, SnippetTranslationResolver translationResolver) {
-        boolean isPageRequest = isPageRequest(handlerMethod);
+        boolean isPageRequest = HandlerMethodUtil.isPageRequest(handlerMethod);
         model.put("isPageRequest", isPageRequest);
         if (isPageRequest) {
             model.put("noContent", false);
         }
     }
 
-    private boolean isPageRequest(HandlerMethod method) {
-        for (MethodParameter param : method.getMethodParameters()) {
-            if (isPageable(param)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean isPageable(MethodParameter param) {
-        return SPRING_DATA_PAGEABLE_CLASS.equals(
-                param.getParameterType().getCanonicalName());
-    }
-
     @Override
-    public String getHeaderKey() {
+    public String getHeaderKey(Operation operation) {
         return "request-parameters";
     }
 

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/section/SectionBuilder.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/section/SectionBuilder.java
@@ -34,6 +34,7 @@ public class SectionBuilder {
             SnippetRegistry.AUTO_AUTHORIZATION,
             SnippetRegistry.AUTO_PATH_PARAMETERS,
             SnippetRegistry.AUTO_REQUEST_PARAMETERS,
+            SnippetRegistry.AUTO_MODELATTRIBUTE,
             SnippetRegistry.AUTO_REQUEST_FIELDS,
             SnippetRegistry.AUTO_RESPONSE_FIELDS,
             SnippetRegistry.AUTO_LINKS,

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/section/SectionSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/section/SectionSnippet.java
@@ -96,7 +96,7 @@ public class SectionSnippet extends TemplatedSnippet {
             if (section != null) {
                 if (!skipEmpty || section.hasContent(operation)) {
                     sections.add(
-                            new Section(section.getFileName(), translationResolver.translate(section.getHeaderKey())));
+                            new Section(section.getFileName(), translationResolver.translate(section.getHeaderKey(operation))));
                 }
             } else {
                 log.warn("Section snippet '" + sectionName + "' is configured to be " +

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/section/SectionSupport.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/section/SectionSupport.java
@@ -29,8 +29,9 @@ public interface SectionSupport {
 
     /**
      * Section header key corresponding to entry in translation file.
+     * @param operation operation
      */
-    String getHeaderKey();
+    String getHeaderKey(Operation operation);
 
     /**
      * Flag if section will render non-empty content.

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/util/HandlerMethodUtil.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/util/HandlerMethodUtil.java
@@ -19,14 +19,8 @@
  */
 package capital.scalable.restdocs.util;
 
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.springframework.util.StringUtils.arrayToDelimitedString;
-
 import org.springframework.core.MethodParameter;
 import org.springframework.web.method.HandlerMethod;
-
-import capital.scalable.restdocs.request.RequestParametersSnippet;
-
 
 public class HandlerMethodUtil {
     private HandlerMethodUtil() {

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/util/HandlerMethodUtil.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/util/HandlerMethodUtil.java
@@ -1,0 +1,51 @@
+/*-
+ * #%L
+ * Spring Auto REST Docs Core
+ * %%
+ * Copyright (C) 2015 - 2019 Scalable Capital GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package capital.scalable.restdocs.util;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.springframework.util.StringUtils.arrayToDelimitedString;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.method.HandlerMethod;
+
+import capital.scalable.restdocs.request.RequestParametersSnippet;
+
+
+public class HandlerMethodUtil {
+    private HandlerMethodUtil() {
+        // util
+    }
+    public static boolean isPageRequest(HandlerMethod method) {
+        for (MethodParameter param : method.getMethodParameters()) {
+            if (isPageable(param)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static final String SPRING_DATA_PAGEABLE_CLASS =
+            "org.springframework.data.domain.Pageable";
+    private static boolean isPageable(MethodParameter param) {
+        return SPRING_DATA_PAGEABLE_CLASS.equals(
+                param.getParameterType().getCanonicalName());
+    }
+
+}

--- a/spring-auto-restdocs-core/src/main/resources/org/springframework/restdocs/templates/asciidoctor/default-auto-modelattribute.snippet
+++ b/spring-auto-restdocs-core/src/main/resources/org/springframework/restdocs/templates/asciidoctor/default-auto-modelattribute.snippet
@@ -1,0 +1,13 @@
+{{#isPageRequest}}{{pagination-request-adoc}}
+
+{{/isPageRequest}}{{#hasContent}}|===
+|{{th-parameter}}|{{th-type}}|{{th-optional}}|{{th-description}}
+
+{{#content}}
+|{{path}}
+|{{type}}
+|{{optional}}
+|{{description}}
+
+{{/content}}
+|==={{/hasContent}}{{#noContent}}{{no-params}}{{/noContent}}

--- a/spring-auto-restdocs-core/src/main/resources/org/springframework/restdocs/templates/markdown/default-auto-modelattribute.snippet
+++ b/spring-auto-restdocs-core/src/main/resources/org/springframework/restdocs/templates/markdown/default-auto-modelattribute.snippet
@@ -1,0 +1,8 @@
+{{#isPageRequest}}{{pagination-request-md}}
+
+{{/isPageRequest}}{{#hasContent}}{{th-parameter}} | {{th-type}} | {{th-optional}} | {{th-description}}
+--------- | ---- | -------- | -----------
+{{#content}}
+{{path}} | {{type}} | {{optional}} | {{description}}
+{{/content}}
+{{/hasContent}}{{#noContent}}{{no-params}}{{/noContent}}

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/payload/JacksonModelAttributeSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/payload/JacksonModelAttributeSnippetTest.java
@@ -19,7 +19,7 @@
  */
 package capital.scalable.restdocs.payload;
 
-import static capital.scalable.restdocs.SnippetRegistry.AUTO_REQUEST_FIELDS;
+import static capital.scalable.restdocs.SnippetRegistry.AUTO_MODELATTRIBUTE;
 import static com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY;
 import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME;
 import static java.util.Collections.singletonList;
@@ -44,10 +44,11 @@ import org.junit.rules.ExpectedException;
 import org.springframework.restdocs.AbstractSnippetTests;
 import org.springframework.restdocs.snippet.SnippetException;
 import org.springframework.restdocs.templates.TemplateFormat;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.method.HandlerMethod;
 
-public class JacksonRequestFieldSnippetTest extends AbstractSnippetTests {
+public class JacksonModelAttributeSnippetTest extends AbstractSnippetTests {
     private ObjectMapper mapper;
     private JavadocReader javadocReader;
     private ConstraintReader constraintReader;
@@ -55,7 +56,7 @@ public class JacksonRequestFieldSnippetTest extends AbstractSnippetTests {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
-    public JacksonRequestFieldSnippetTest(String name, TemplateFormat templateFormat) {
+    public JacksonModelAttributeSnippetTest(String name, TemplateFormat templateFormat) {
         super(name, templateFormat);
     }
 
@@ -76,15 +77,15 @@ public class JacksonRequestFieldSnippetTest extends AbstractSnippetTests {
         mockOptionalMessage(Item.class, "field1", "false");
         mockConstraintMessage(Item.class, "field2", "A constraint");
 
-        new JacksonRequestFieldSnippet().document(operationBuilder
+        new JacksonModelAttributeSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
                 .attribute(ObjectMapper.class.getName(), mapper)
                 .attribute(JavadocReader.class.getName(), javadocReader)
                 .attribute(ConstraintReader.class.getName(), constraintReader)
                 .build());
 
-        assertThat(this.generatedSnippets.snippet(AUTO_REQUEST_FIELDS)).is(
-                tableWithHeader("Path", "Type", "Optional", "Description")
+        assertThat(this.generatedSnippets.snippet(AUTO_MODELATTRIBUTE)).is(
+                tableWithHeader("Parameter", "Type", "Optional", "Description")
                         .row("field1", "String", "false", "A string.")
                         .row("field2", "Integer", "true", "An integer.\n\nA constraint."));
     }
@@ -96,38 +97,37 @@ public class JacksonRequestFieldSnippetTest extends AbstractSnippetTests {
         mockFieldComment(ItemWithWeight.class, "weight", "An enum");
         mockConstraintMessage(ItemWithWeight.class, "weight", "Must be one of [LIGHT, HEAVY]");
 
-        new JacksonRequestFieldSnippet().document(operationBuilder
+        new JacksonModelAttributeSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
                 .attribute(ObjectMapper.class.getName(), mapper)
                 .attribute(JavadocReader.class.getName(), javadocReader)
                 .attribute(ConstraintReader.class.getName(), constraintReader)
                 .build());
 
-        assertThat(this.generatedSnippets.snippet(AUTO_REQUEST_FIELDS)).is(
-                tableWithHeader("Path", "Type", "Optional", "Description")
+        assertThat(this.generatedSnippets.snippet(AUTO_MODELATTRIBUTE)).is(
+                tableWithHeader("Parameter", "Type", "Optional", "Description")
                         .row("weight", "String", "true",
                                 "An enum.\n\nMust be one of [LIGHT, HEAVY]."));
     }
 
     @Test
-    public void noRequestBody() throws Exception {
+    public void noParameters() throws Exception {
         HandlerMethod handlerMethod = new HandlerMethod(new TestResource(), "addItem2");
 
-        new JacksonRequestFieldSnippet().document(operationBuilder
-                .attribute(HandlerMethod.class.getName(), handlerMethod)
-                .attribute(ObjectMapper.class.getName(), mapper)
-                .build());
+        new JacksonModelAttributeSnippet()
+                .document(operationBuilder.attribute(HandlerMethod.class.getName(), handlerMethod)
+                        .attribute(ObjectMapper.class.getName(), mapper).build());
 
-        assertThat(this.generatedSnippets.snippet(AUTO_REQUEST_FIELDS)).isEqualTo("No request body.");
+        assertThat(this.generatedSnippets.snippet(AUTO_MODELATTRIBUTE)).isEqualTo("No parameters.");
     }
 
     @Test
     public void noHandlerMethod() throws Exception {
-        new JacksonRequestFieldSnippet().document(operationBuilder
+        new JacksonModelAttributeSnippet().document(operationBuilder
                 .attribute(ObjectMapper.class.getName(), mapper)
                 .build());
 
-        assertThat(this.generatedSnippets.snippet(AUTO_REQUEST_FIELDS)).isEqualTo("No request body.");
+        assertThat(this.generatedSnippets.snippet(AUTO_MODELATTRIBUTE)).isEqualTo("No parameters.");
     }
 
     @Test
@@ -136,15 +136,15 @@ public class JacksonRequestFieldSnippetTest extends AbstractSnippetTests {
         mockFieldComment(Item.class, "field1", "A string");
         mockFieldComment(Item.class, "field2", "An integer");
 
-        new JacksonRequestFieldSnippet().document(operationBuilder
+        new JacksonModelAttributeSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
                 .attribute(ObjectMapper.class.getName(), mapper)
                 .attribute(JavadocReader.class.getName(), javadocReader)
                 .attribute(ConstraintReader.class.getName(), mock(ConstraintReader.class))
                 .build());
 
-        assertThat(this.generatedSnippets.snippet(AUTO_REQUEST_FIELDS)).is(
-                tableWithHeader("Path", "Type", "Optional", "Description")
+        assertThat(this.generatedSnippets.snippet(AUTO_MODELATTRIBUTE)).is(
+                tableWithHeader("Parameter", "Type", "Optional", "Description")
                         .row("[].field1", "String", "true", "A string.")
                         .row("[].field2", "Integer", "true", "An integer."));
     }
@@ -157,26 +157,27 @@ public class JacksonRequestFieldSnippetTest extends AbstractSnippetTests {
         mockFieldComment(SubItem1.class, "subItem1Field", "A sub item 1 field");
         mockFieldComment(SubItem2.class, "subItem2Field", "A sub item 2 field");
 
-        new JacksonRequestFieldSnippet().document(operationBuilder
+        new JacksonModelAttributeSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
                 .attribute(ObjectMapper.class.getName(), mapper)
                 .attribute(JavadocReader.class.getName(), javadocReader)
                 .attribute(ConstraintReader.class.getName(), constraintReader)
                 .build());
 
-        assertThat(this.generatedSnippets.snippet(AUTO_REQUEST_FIELDS)).is(
-                tableWithHeader("Path", "Type", "Optional", "Description")
+        assertThat(this.generatedSnippets.snippet(AUTO_MODELATTRIBUTE)).is(
+                tableWithHeader("Parameter", "Type", "Optional", "Description")
                         .row("type", "String", "true", "A type.")
                         .row("commonField", "String", "true", "A common field.")
                         .row("subItem1Field", "Boolean", "true", "A sub item 1 field.")
                         .row("subItem2Field", "Integer", "true", "A sub item 2 field."));
     }
 
+
     @Test
-    public void hasContentWithRequestBodyAnnotation() throws Exception {
+    public void hasContentWithModelAttributeAnnotation() throws Exception {
         HandlerMethod handlerMethod = createHandlerMethod("addItem", Item.class);
 
-        boolean hasContent = new JacksonRequestFieldSnippet().hasContent(operationBuilder
+        boolean hasContent = new JacksonModelAttributeSnippet().hasContent(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
                 .build());
         assertThat(hasContent).isTrue();
@@ -186,20 +187,33 @@ public class JacksonRequestFieldSnippetTest extends AbstractSnippetTests {
     public void noContent() throws Exception {
         HandlerMethod handlerMethod = createHandlerMethod("addItem2");
 
-        boolean hasContent = new JacksonRequestFieldSnippet().hasContent(operationBuilder
+        boolean hasContent = new JacksonModelAttributeSnippet().hasContent(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
                 .build());
         assertThat(hasContent).isFalse();
     }
 
     @Test
-    public void failOnUndocumentedFields() throws Exception {
+    public void failOnUndocumentedParameters() throws Exception {
         HandlerMethod handlerMethod = createHandlerMethod("addItem", Item.class);
+
+        thrown.expect(SnippetException.class);
+        thrown.expectMessage("Following query parameters were not documented: [field1, field2]");
+
+        new JacksonModelAttributeSnippet(null, true).document(operationBuilder
+                .attribute(HandlerMethod.class.getName(), handlerMethod).attribute(ObjectMapper.class.getName(), mapper)
+                .attribute(JavadocReader.class.getName(), javadocReader)
+                .attribute(ConstraintReader.class.getName(), constraintReader).build());
+    }
+
+    @Test
+    public void failOnUndocumentedFields() throws Exception {
+        HandlerMethod handlerMethod = createHandlerMethod("addItemPost", Item.class);
 
         thrown.expect(SnippetException.class);
         thrown.expectMessage("Following request fields were not documented: [field1, field2]");
 
-        new JacksonRequestFieldSnippet().failOnUndocumentedFields(true).document(operationBuilder
+        new JacksonModelAttributeSnippet(null, true).document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
                 .attribute(ObjectMapper.class.getName(), mapper)
                 .attribute(JavadocReader.class.getName(), javadocReader)
@@ -213,15 +227,15 @@ public class JacksonRequestFieldSnippetTest extends AbstractSnippetTests {
         mockFieldComment(DeprecatedItem.class, "index", "item's index");
         mockDeprecated(DeprecatedItem.class, "index", "use index2");
 
-        new JacksonRequestFieldSnippet().document(operationBuilder
+        new JacksonModelAttributeSnippet().document(operationBuilder
                 .attribute(HandlerMethod.class.getName(), handlerMethod)
                 .attribute(ObjectMapper.class.getName(), mapper)
                 .attribute(JavadocReader.class.getName(), javadocReader)
                 .attribute(ConstraintReader.class.getName(), constraintReader)
                 .build());
 
-        assertThat(this.generatedSnippets.snippet(AUTO_REQUEST_FIELDS)).is(
-                tableWithHeader("Path", "Type", "Optional", "Description")
+        assertThat(this.generatedSnippets.snippet(AUTO_MODELATTRIBUTE)).is(
+                tableWithHeader("Parameter", "Type", "Optional", "Description")
                         .row("index", "Integer", "true",
                                 "**Deprecated.** Use index2.\n\nItem's index."));
     }
@@ -253,15 +267,20 @@ public class JacksonRequestFieldSnippetTest extends AbstractSnippetTests {
 
     private static class TestResource {
 
-        public void addItem(@RequestBody Item item) {
+        public void addItem(@ModelAttribute Item item) {
             // NOOP
         }
 
-        public void addItemWithWeight(@RequestBody ItemWithWeight item) {
+        @PostMapping
+        public void addItemPost(@ModelAttribute Item item) {
             // NOOP
         }
 
-        public void addItems(@RequestBody List<Item> items) {
+        public void addItemWithWeight(@ModelAttribute ItemWithWeight item) {
+            // NOOP
+        }
+
+        public void addItems(@ModelAttribute List<Item> items) {
             // NOOP
         }
 
@@ -269,12 +288,12 @@ public class JacksonRequestFieldSnippetTest extends AbstractSnippetTests {
             // NOOP
         }
 
-        public void addSubItem(@RequestBody ParentItem item) {
+        public void addSubItem(@ModelAttribute ParentItem item) {
             // NOOP
         }
 
 
-        public void removeItem(@RequestBody DeprecatedItem item) {
+        public void removeItem(@ModelAttribute DeprecatedItem item) {
             // NOOP
         }
     }


### PR DESCRIPTION
fix for #355 
ModelAttribute is an optional annotation. By default, any argument that is not a simple value type (as determined by BeanUtils#isSimpleProperty) and is not resolved by any other argument resolver is treated as if it were annotated with @ModelAttribute.
This pull request fixes also section header. If operation is annotated with RequestMethod GET, section header is "query parameter".
 