### PR TITLE
Replacement for binary content of multipart requests

### DIFF
--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/response/MultipartContentOperationPreprocessor.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/response/MultipartContentOperationPreprocessor.java
@@ -1,0 +1,44 @@
+package capital.scalable.restdocs.response;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.operation.OperationRequest;
+import org.springframework.restdocs.operation.OperationRequestFactory;
+import org.springframework.restdocs.operation.OperationRequestPart;
+import org.springframework.restdocs.operation.OperationRequestPartFactory;
+import org.springframework.restdocs.operation.preprocess.OperationPreprocessorAdapter;
+
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.toList;
+
+public class MultipartContentOperationPreprocessor extends OperationPreprocessorAdapter {
+    private static final byte[] BINARY_REPLACEMENT = "<binary>".getBytes(UTF_8);
+
+    private final OperationRequestPartFactory partFactory = new OperationRequestPartFactory();
+    private final OperationRequestFactory requestFactory = new OperationRequestFactory();
+
+    @Override
+    public OperationRequest preprocess(OperationRequest request) {
+        if (isMultipart(request)) {
+            List<OperationRequestPart> parts = request.getParts().stream()
+                    .map(this::replaceBinary)
+                    .collect(toList());
+            return requestFactory.create(request.getUri(),
+                    request.getMethod(), request.getContent(), request.getHeaders(), request.getParameters()
+                    , parts);
+        }
+        return request;
+    }
+
+    private boolean isMultipart(OperationRequest request) {
+        List<String> contentTypes = request.getHeaders().get(HttpHeaders.CONTENT_TYPE);
+        return contentTypes != null && contentTypes.contains(MediaType.MULTIPART_FORM_DATA_VALUE);
+    }
+
+    private OperationRequestPart replaceBinary(OperationRequestPart part) {
+        return partFactory.create(part.getName(), part.getSubmittedFileName()
+                , BINARY_REPLACEMENT, part.getHeaders());
+    }
+}

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/response/ResponseModifyingPreprocessors.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/response/ResponseModifyingPreprocessors.java
@@ -50,6 +50,15 @@ public class ResponseModifyingPreprocessors {
     }
 
     /**
+     * For binary content of multipart/form-data requests, replaces value with "&lt;binary&gt;".
+     *
+     * @return a preprocessor replacing binary content of multipart/form-data requests
+     */
+    public static OperationPreprocessor replaceMultipartBinaryContent() {
+        return new MultipartContentOperationPreprocessor();
+    }
+
+    /**
      * For JSON content, cuts the length of all JSON arrays in the response to 3 elements.
      *
      * @param objectMapper object mapper to use

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/response/MultipartContentOperationPreprocessorTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/response/MultipartContentOperationPreprocessorTest.java
@@ -1,0 +1,79 @@
+package capital.scalable.restdocs.response;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.operation.OperationRequest;
+import org.springframework.restdocs.operation.OperationRequestFactory;
+import org.springframework.restdocs.operation.OperationRequestPart;
+import org.springframework.restdocs.operation.OperationRequestPartFactory;
+import org.springframework.restdocs.operation.Parameters;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class MultipartContentOperationPreprocessorTest {
+    private static final byte[] EXPECTED_CONTENT = "<binary>".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] BINARY_CONTENT = new byte[]{1, 2, 3, 3, 3};
+    private MultipartContentOperationPreprocessor preprocessor;
+    private OperationRequestFactory requestFactory;
+    private OperationRequestPartFactory partFactory;
+
+    @Before
+    public void setUp() {
+        preprocessor = new MultipartContentOperationPreprocessor();
+        requestFactory = new OperationRequestFactory();
+        partFactory = new OperationRequestPartFactory();
+    }
+
+    @Test
+    public void shouldReplaceContent() throws URISyntaxException {
+        OperationRequest request = createRequestWithContentType(MediaType.MULTIPART_FORM_DATA_VALUE);
+
+        OperationRequest processedRequest = preprocessor.preprocess(request);
+        assertArrayEquals(request.getContent(), processedRequest.getContent());
+        assertEquals(request.getHeaders(), processedRequest.getHeaders());
+        assertEquals(request.getMethod(), processedRequest.getMethod());
+        assertEquals(request.getUri(), processedRequest.getUri());
+        assertEquals(request.getParameters(), processedRequest.getParameters());
+        for (OperationRequestPart part : processedRequest.getParts()) {
+            assertArrayEquals(EXPECTED_CONTENT, part.getContent());
+        }
+    }
+
+    @Test
+    public void shouldNotReplaceWhenNotMultipart() throws URISyntaxException {
+        OperationRequest request = createRequestWithContentType(MediaType.APPLICATION_OCTET_STREAM_VALUE);
+
+        OperationRequest processedRequest = preprocessor.preprocess(request);
+        assertArrayEquals(request.getContent(), processedRequest.getContent());
+        assertEquals(request.getHeaders(), processedRequest.getHeaders());
+        assertEquals(request.getMethod(), processedRequest.getMethod());
+        assertEquals(request.getUri(), processedRequest.getUri());
+        assertEquals(request.getParameters(), processedRequest.getParameters());
+
+        OperationRequestPart[] expectedParts = request.getParts().toArray(new OperationRequestPart[0]);
+        OperationRequestPart[] operationRequestParts = processedRequest.getParts().toArray(new OperationRequestPart[0]);
+        for (int i = 0; i < operationRequestParts.length; i++) {
+            assertEquals(expectedParts[i], operationRequestParts[i]);
+        }
+    }
+
+    private OperationRequest createRequestWithContentType(String contentType) throws URISyntaxException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.CONTENT_TYPE, contentType);
+        Parameters parameters = new Parameters();
+        parameters.add("parameter", "value");
+        List<OperationRequestPart> requestParts = new ArrayList<>();
+        requestParts.add(partFactory.create("first", "file1", BINARY_CONTENT, new HttpHeaders()));
+        return requestFactory.create(new URI("http://localhost"), HttpMethod.POST, BINARY_CONTENT, headers, parameters, requestParts);
+    }
+}

--- a/spring-auto-restdocs-docs/other.adoc
+++ b/spring-auto-restdocs-docs/other.adoc
@@ -22,6 +22,7 @@ See example project for link:{example-dir}/src/main/asciidoc/index.adoc#overview
 Preprocessors are available for use in order to improve quality of endpoint examples.
 
 - link:{core-package}/response/BinaryReplacementContentModifier.java[binary replacement]: replaces content with `<binary>` for common mime types
+- link:{core-package}/response/MultipartContentOperationPreprocessor.java[multipart binary replacement]: replaces content with `<binary>` for multipart/form-data requests
 - link:{core-package}/response/ArrayLimitingJsonContentModifier.java[limit JSON array length]: limits all JSON arrays to 3 items
 
 For a list of standard preprocessors see link:{restdocs-package}/operation/preprocess/Preprocessors.java[Preprocessors].


### PR DESCRIPTION
This PR adds MultipartContentOperationPreprocessor for replacing binary content of multipart/form-data requests