### PR TITLE
Travis: Switch to Ubuntu 16.04 & OpenJDK, sudo keyword deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
-sudo: false
-dist: trusty
+dist: bionic
 jdk:
 - oraclejdk8
 - oraclejdk9

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: java
-dist: bionic
+dist: xenial
 jdk:
-- oraclejdk8
-- oraclejdk9
+- openjdk8
+- openjdk9
 - openjdk10
 - openjdk11
 before_cache:
@@ -22,17 +22,17 @@ script:
 - cd samples
 - mvn install -B -V
 - cd java-webmvc && ./gradlew check && cd ..
-- test "$TRAVIS_JDK_VERSION" = "oraclejdk8" && cd kotlin-webmvc && ./gradlew check && cd .. || (exit 0)
+- test "$TRAVIS_JDK_VERSION" = "openjdk8" && cd kotlin-webmvc && ./gradlew check && cd .. || (exit 0)
 after_success:
 - echo $GPG_SECRET_KEYS | base64 --decode | gpg --import
 - cd $TRAVIS_BUILD_DIR
 - echo TRAVIS_PULL_REQUEST=\"$TRAVIS_PULL_REQUEST\"
 - echo TRAVIS_JDK_VERSION=\"$TRAVIS_JDK_VERSION\"
 - test "$TRAVIS_PULL_REQUEST" = "false"
-  && test "$TRAVIS_JDK_VERSION" = "oraclejdk8"
+  && test "$TRAVIS_JDK_VERSION" = "openjdk8"
   && mvn deploy --settings travis-settings.xml -DskipTests=true -B -V
 - test "$TRAVIS_PULL_REQUEST" = "false"
-  && test "$TRAVIS_JDK_VERSION" = "oraclejdk9"
+  && test "$TRAVIS_JDK_VERSION" = "openjdk9"
   && cd spring-auto-restdocs-json-doclet-jdk9
   && mvn deploy --settings ../travis-settings.xml -DskipTests=true -B -V
 branches:


### PR DESCRIPTION
* Switch from Ubuntu 14.04 to Ubuntu 16.04. Travis does not support Java 8 on Ubuntu 18.04.
* Switched to OpenJDK for all versions because it's better supported.
* sudo keyword deprecated
"Over the next few weeks, we encourage everyone to remove any sudo: false configurations from your .travis.yml. Soon we will run all projects on the virtual-machine-based infrastructure, the sudo keyword will be fully deprecated."
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration#timeline---its-happening-fast