### PR TITLE
Support for @JsonProperty.Access

### DIFF
--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/FieldDocumentationArrayVisitor.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/FieldDocumentationArrayVisitor.java
@@ -19,6 +19,7 @@
  */
 package capital.scalable.restdocs.jackson;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.SerializerProvider;
@@ -33,15 +34,17 @@ class FieldDocumentationArrayVisitor extends JsonArrayFormatVisitor.Base {
     private final String path;
     private final TypeRegistry typeRegistry;
     private final TypeFactory typeFactory;
+    private final JsonProperty.Access skipAccessor;
 
     public FieldDocumentationArrayVisitor(SerializerProvider provider,
             FieldDocumentationVisitorContext context, String path, TypeRegistry typeRegistry,
-            TypeFactory typeFactory) {
+            TypeFactory typeFactory, JsonProperty.Access skipAccessor) {
         super(provider);
         this.context = context;
         this.path = path;
         this.typeRegistry = typeRegistry;
         this.typeFactory = typeFactory;
+        this.skipAccessor = skipAccessor;
     }
 
     @Override
@@ -49,7 +52,7 @@ class FieldDocumentationArrayVisitor extends JsonArrayFormatVisitor.Base {
             throws JsonMappingException {
         String elementPath = path + "[]";
         JsonFormatVisitorWrapper visitor = new FieldDocumentationVisitorWrapper(getProvider(),
-                context, elementPath, null, typeRegistry, typeFactory);
+                context, elementPath, null, typeRegistry, typeFactory, skipAccessor);
         handler.acceptJsonFormatVisitor(visitor, elementType);
     }
 }

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/FieldDocumentationGenerator.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/FieldDocumentationGenerator.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,6 +31,7 @@ import java.util.Set;
 import capital.scalable.restdocs.constraints.ConstraintReader;
 import capital.scalable.restdocs.i18n.SnippetTranslationResolver;
 import capital.scalable.restdocs.javadoc.JavadocReader;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -52,18 +53,24 @@ public class FieldDocumentationGenerator {
     private final ConstraintReader constraintReader;
     private final TypeMapping typeMapping;
     private final SnippetTranslationResolver translationResolver;
+    private final JsonProperty.Access skipAccessor;
 
-    public FieldDocumentationGenerator(ObjectWriter writer,
-                                       DeserializationConfig deserializationConfig,
-                                       JavadocReader javadocReader,
-                                       ConstraintReader constraintReader,
-                                       TypeMapping typeMapping, SnippetTranslationResolver translationResolver) {
+    public FieldDocumentationGenerator(
+            ObjectWriter writer,
+            DeserializationConfig deserializationConfig,
+            JavadocReader javadocReader,
+            ConstraintReader constraintReader,
+            TypeMapping typeMapping,
+            SnippetTranslationResolver translationResolver,
+            JsonProperty.Access skipAccessor
+    ) {
         this.writer = writer;
         this.deserializationConfig = deserializationConfig;
         this.javadocReader = javadocReader;
         this.constraintReader = constraintReader;
         this.typeMapping = typeMapping;
         this.translationResolver = translationResolver;
+        this.skipAccessor = skipAccessor;
     }
 
     public FieldDescriptors generateDocumentation(Type baseType, TypeFactory typeFactory)
@@ -74,7 +81,7 @@ public class FieldDocumentationGenerator {
 
         FieldDocumentationVisitorWrapper visitorWrapper = FieldDocumentationVisitorWrapper.create(
                 javadocReader, constraintReader, deserializationConfig,
-                new TypeRegistry(typeMapping, types), typeFactory, translationResolver);
+                new TypeRegistry(typeMapping, types), typeFactory, translationResolver, skipAccessor);
 
         for (JavaType type : types) {
             log.debug("(TOP) {}", type.getRawClass().getSimpleName());

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/FieldDocumentationObjectVisitor.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/FieldDocumentationObjectVisitor.java
@@ -2,7 +2,7 @@
  * #%L
  * Spring Auto REST Docs Core
  * %%
- * Copyright (C) 2015 - 2019 Scalable Capital GmbH
+ * Copyright (C) 2015 - 2020 Scalable Capital GmbH
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,10 +93,8 @@ class FieldDocumentationObjectVisitor extends JsonObjectFormatVisitor.Base {
     }
 
     public void property(BeanProperty prop, boolean required) throws JsonMappingException {
-        JsonProperty jsonProperty = prop.getMember().getAnnotation(JsonProperty.class);
-        if (jsonProperty != null && skipAccessor == jsonProperty.access()) {
+        if (skipProperty(prop))
             return;
-        }
 
         String jsonName = prop.getName();
         String fieldName = prop.getMember().getName();
@@ -114,9 +112,13 @@ class FieldDocumentationObjectVisitor extends JsonObjectFormatVisitor.Base {
                 return;
             }
 
-
             visitType(prop, jsonName, fieldName, javaType, ser, required);
         }
+    }
+
+    private boolean skipProperty(BeanProperty prop) {
+        JsonProperty jsonProperty = prop.getMember().getAnnotation(JsonProperty.class);
+        return jsonProperty != null && skipAccessor == jsonProperty.access();
     }
 
     private void visitType(BeanProperty prop, String jsonName, String fieldName, JavaType fieldType,

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/JacksonResultHandlers.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/JacksonResultHandlers.java
@@ -79,7 +79,7 @@ public abstract class JacksonResultHandlers {
         private final ConstraintDescriptionResolver constraintDescriptionResolver;
 
         public JacksonPreparingResultHandler(ObjectMapper objectMapper, TypeMapping typeMapping, SnippetTranslationResolver translationResolver, ConstraintDescriptionResolver constraintDescriptionResolver) {
-            this.objectMapper = objectMapper;
+            this.objectMapper = new SardObjectMapper(objectMapper);
             this.typeMapping = typeMapping;
             this.translationResolver = translationResolver;
             this.constraintDescriptionResolver = constraintDescriptionResolver;

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/SardObjectMapper.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/SardObjectMapper.java
@@ -1,0 +1,41 @@
+package capital.scalable.restdocs.jackson;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.cfg.MapperConfig;
+import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
+import com.fasterxml.jackson.databind.introspect.BasicClassIntrospector;
+import com.fasterxml.jackson.databind.introspect.ClassIntrospector;
+import com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector;
+import com.fasterxml.jackson.databind.introspect.POJOPropertyBuilder;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class SardObjectMapper extends ObjectMapper {
+    public SardObjectMapper(ObjectMapper objectMapper) {
+        super(objectMapper);
+        this.setConfig(getSerializationConfig().with(new SardClassIntrospector()));
+    }
+
+    public static class SardClassIntrospector extends BasicClassIntrospector {
+        @Override
+        protected POJOPropertiesCollector constructPropertyCollector(MapperConfig<?> config, AnnotatedClass ac,
+                JavaType type, boolean forSerialization, String mutatorPrefix) {
+            return new SardPOJOPropertiesCollector(config, forSerialization, type, ac, mutatorPrefix);
+        }
+    }
+
+    public static class SardPOJOPropertiesCollector extends POJOPropertiesCollector {
+
+        protected SardPOJOPropertiesCollector(MapperConfig<?> config, boolean forSerialization,
+                JavaType type, AnnotatedClass classDef, String mutatorPrefix) {
+            super(config, forSerialization, type, classDef, mutatorPrefix);
+        }
+
+        @Override
+        protected void _removeUnwantedAccessor(Map<String, POJOPropertyBuilder> props) {
+            // keep everything
+        }
+    }
+}

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/SardObjectMapper.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/jackson/SardObjectMapper.java
@@ -1,17 +1,41 @@
+/*-
+ * #%L
+ * Spring Auto REST Docs Core
+ * %%
+ * Copyright (C) 2015 - 2020 Scalable Capital GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package capital.scalable.restdocs.jackson;
 
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.cfg.MapperConfig;
 import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
 import com.fasterxml.jackson.databind.introspect.BasicClassIntrospector;
-import com.fasterxml.jackson.databind.introspect.ClassIntrospector;
 import com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector;
 import com.fasterxml.jackson.databind.introspect.POJOPropertyBuilder;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 
+/**
+ * Overrides class inspector so that we keep properties othewise filtered out via {@link JsonProperty#access()} in
+ * {@link POJOPropertiesCollector#_removeUnwantedAccessor(java.util.Map)}.
+ * The actual filtering happens now in
+ * {@link FieldDocumentationObjectVisitor#skipProperty(com.fasterxml.jackson.databind.BeanProperty)}
+ */
 public class SardObjectMapper extends ObjectMapper {
     public SardObjectMapper(ObjectMapper objectMapper) {
         super(objectMapper);

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonModelAttributeSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonModelAttributeSnippet.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.beans.BeanUtils;
 import org.springframework.core.MethodParameter;
 import org.springframework.restdocs.operation.Operation;
@@ -140,5 +141,10 @@ public class JacksonModelAttributeSnippet extends AbstractJacksonFieldSnippet {
             "pagination-request-md",
             "no-params"
         };
+    }
+
+    @Override
+    protected JsonProperty.Access getSkipAcessor() {
+        return JsonProperty.Access.READ_ONLY;
     }
 }

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonRequestFieldSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonRequestFieldSnippet.java
@@ -25,6 +25,7 @@ import static capital.scalable.restdocs.util.TypeUtil.firstGenericType;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Type;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.core.MethodParameter;
 import org.springframework.restdocs.operation.Operation;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -98,5 +99,10 @@ public class JacksonRequestFieldSnippet extends AbstractJacksonFieldSnippet {
                 "th-description",
                 "no-request-body"
         };
+    }
+
+    @Override
+    protected JsonProperty.Access getSkipAcessor() {
+        return JsonProperty.Access.READ_ONLY;
     }
 }

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippet.java
@@ -33,6 +33,7 @@ import java.util.Set;
 
 import capital.scalable.restdocs.i18n.SnippetTranslationResolver;
 import capital.scalable.restdocs.jackson.FieldDescriptors;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.http.HttpEntity;
 import org.springframework.restdocs.operation.Operation;
 import org.springframework.web.method.HandlerMethod;
@@ -140,5 +141,10 @@ public class JacksonResponseFieldSnippet extends AbstractJacksonFieldSnippet {
                 "pagination-response-md",
                 "no-response-body"
         };
+    }
+
+    @Override
+    protected JsonProperty.Access getSkipAcessor() {
+        return JsonProperty.Access.WRITE_ONLY;
     }
 }

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/jackson/FieldDocumentationGeneratorTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/jackson/FieldDocumentationGeneratorTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -83,7 +83,8 @@ public class FieldDocumentationGeneratorTest {
 
         FieldDocumentationGenerator generator =
                 new FieldDocumentationGenerator(mapper.writer(), mapper.getDeserializationConfig(),
-                        javadocReader, constraintReader, typeMapping, SnippetTranslationManager.getDefaultResolver());
+                        javadocReader, constraintReader, typeMapping, SnippetTranslationManager.getDefaultResolver(),
+                        null);
         Type type = BasicTypes.class;
 
         // when
@@ -108,7 +109,8 @@ public class FieldDocumentationGeneratorTest {
 
         FieldDocumentationGenerator generator =
                 new FieldDocumentationGenerator(mapper.writer(),
-                        mapper.getDeserializationConfig(), javadocReader, constraintReader, typeMapping, SnippetTranslationManager.getDefaultResolver());
+                        mapper.getDeserializationConfig(), javadocReader, constraintReader, typeMapping,
+                        SnippetTranslationManager.getDefaultResolver(), null);
         Type type = PrimitiveTypes.class;
 
         // when
@@ -124,7 +126,8 @@ public class FieldDocumentationGeneratorTest {
         // when change deserialization config
         mapper.configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, true);
         generator = new FieldDocumentationGenerator(mapper.writer(),
-                mapper.getDeserializationConfig(), javadocReader, constraintReader, typeMapping, SnippetTranslationManager.getDefaultResolver());
+                mapper.getDeserializationConfig(), javadocReader, constraintReader, typeMapping,
+                SnippetTranslationManager.getDefaultResolver(), null);
 
         // when
         result = cast(generator.generateDocumentation(type, mapper.getTypeFactory()).values());
@@ -150,7 +153,8 @@ public class FieldDocumentationGeneratorTest {
 
         FieldDocumentationGenerator generator =
                 new FieldDocumentationGenerator(mapper.writer(),
-                        mapper.getDeserializationConfig(), javadocReader, constraintReader, typeMapping, SnippetTranslationManager.getDefaultResolver());
+                        mapper.getDeserializationConfig(), javadocReader, constraintReader, typeMapping,
+                        SnippetTranslationManager.getDefaultResolver(), null);
         Type type = ComposedTypes.class;
 
         // when
@@ -193,7 +197,8 @@ public class FieldDocumentationGeneratorTest {
 
         FieldDocumentationGenerator generator =
                 new FieldDocumentationGenerator(mapper.writer(),
-                        mapper.getDeserializationConfig(), javadocReader, constraintReader, typeMapping, SnippetTranslationManager.getDefaultResolver());
+                        mapper.getDeserializationConfig(), javadocReader, constraintReader, typeMapping,
+                        SnippetTranslationManager.getDefaultResolver(), null);
         Type type = FirstLevel.class;
 
         // when
@@ -221,7 +226,8 @@ public class FieldDocumentationGeneratorTest {
         // given
         ObjectMapper mapper = createMapper();
         FieldDocumentationGenerator generator = new FieldDocumentationGenerator(mapper.writer(),
-                mapper.getDeserializationConfig(), javadocReader, constraintReader, typeMapping, SnippetTranslationManager.getDefaultResolver());
+                mapper.getDeserializationConfig(), javadocReader, constraintReader, typeMapping,
+                SnippetTranslationManager.getDefaultResolver(), null);
         Type type = RecursiveType.class;
 
         // when
@@ -260,7 +266,8 @@ public class FieldDocumentationGeneratorTest {
 
         FieldDocumentationGenerator generator =
                 new FieldDocumentationGenerator(mapper.writer(),
-                        mapper.getDeserializationConfig(), javadocReader, constraintReader, typeMapping, SnippetTranslationManager.getDefaultResolver());
+                        mapper.getDeserializationConfig(), javadocReader, constraintReader, typeMapping,
+                        SnippetTranslationManager.getDefaultResolver(), null);
         Type type = ExternalSerializer.class;
 
         // when
@@ -285,7 +292,8 @@ public class FieldDocumentationGeneratorTest {
 
         FieldDocumentationGenerator generator =
                 new FieldDocumentationGenerator(mapper.writer(),
-                        mapper.getDeserializationConfig(), javadocReader, constraintReader, typeMapping, SnippetTranslationManager.getDefaultResolver());
+                        mapper.getDeserializationConfig(), javadocReader, constraintReader, typeMapping,
+                        SnippetTranslationManager.getDefaultResolver(), null);
         Type type = JsonAnnotations.class;
 
         // when
@@ -323,7 +331,8 @@ public class FieldDocumentationGeneratorTest {
 
         FieldDocumentationGenerator generator =
                 new FieldDocumentationGenerator(mapper.writer(),
-                        mapper.getDeserializationConfig(), javadocReader, constraintReader, typeMapping, SnippetTranslationManager.getDefaultResolver());
+                        mapper.getDeserializationConfig(), javadocReader, constraintReader, typeMapping,
+                        SnippetTranslationManager.getDefaultResolver(), null);
         Type type = FieldCommentResolution.class;
 
         // when
@@ -356,7 +365,8 @@ public class FieldDocumentationGeneratorTest {
 
         FieldDocumentationGenerator generator =
                 new FieldDocumentationGenerator(mapper.writer(),
-                        mapper.getDeserializationConfig(), javadocReader, constraintReader, typeMapping, SnippetTranslationManager.getDefaultResolver());
+                        mapper.getDeserializationConfig(), javadocReader, constraintReader, typeMapping,
+                        SnippetTranslationManager.getDefaultResolver(), null);
         Type type = ConstraintResolution.class;
 
         // when
@@ -398,7 +408,8 @@ public class FieldDocumentationGeneratorTest {
 
         FieldDocumentationGenerator generator =
                 new FieldDocumentationGenerator(mapper.writer(),
-                        mapper.getDeserializationConfig(), javadocReader, constraintReader, typeMapping, SnippetTranslationManager.getDefaultResolver());
+                        mapper.getDeserializationConfig(), javadocReader, constraintReader, typeMapping,
+                        SnippetTranslationManager.getDefaultResolver(), null);
         Type type = JsonType1.class;
 
         // when
@@ -463,7 +474,8 @@ public class FieldDocumentationGeneratorTest {
 
         FieldDocumentationGenerator generator =
                 new FieldDocumentationGenerator(mapper.writer(),
-                        mapper.getDeserializationConfig(), javadocReader, constraintReader, typeMapping, SnippetTranslationManager.getDefaultResolver());
+                        mapper.getDeserializationConfig(), javadocReader, constraintReader, typeMapping,
+                        SnippetTranslationManager.getDefaultResolver(), null);
         Type type = Plain.class;
 
         // when
@@ -496,7 +508,8 @@ public class FieldDocumentationGeneratorTest {
 
         FieldDocumentationGenerator generator =
                 new FieldDocumentationGenerator(mapper.writer(), mapper.getDeserializationConfig(),
-                        javadocReader, constraintReader, typeMapping, SnippetTranslationManager.getDefaultResolver());
+                        javadocReader, constraintReader, typeMapping, SnippetTranslationManager.getDefaultResolver(),
+                        null);
         Type type = BasicTypes.class;
 
         // when
@@ -520,7 +533,8 @@ public class FieldDocumentationGeneratorTest {
 
         FieldDocumentationGenerator generator =
                 new FieldDocumentationGenerator(mapper.writer(), mapper.getDeserializationConfig(),
-                        javadocReader, constraintReader, typeMapping, SnippetTranslationManager.getDefaultResolver());
+                        javadocReader, constraintReader, typeMapping, SnippetTranslationManager.getDefaultResolver(),
+                        null);
         Type type = RequiredProperties.class;
 
         // when

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/payload/JacksonModelAttributeSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/payload/JacksonModelAttributeSnippetTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Spring Auto REST Docs Core
  * %%
- * Copyright (C) 2015 - 2019 Scalable Capital GmbH
+ * Copyright (C) 2015 - 2020 Scalable Capital GmbH
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,9 @@
 package capital.scalable.restdocs.payload;
 
 import static capital.scalable.restdocs.SnippetRegistry.AUTO_MODELATTRIBUTE;
+import static capital.scalable.restdocs.SnippetRegistry.AUTO_REQUEST_FIELDS;
+import static com.fasterxml.jackson.annotation.JsonProperty.Access.READ_ONLY;
+import static com.fasterxml.jackson.annotation.JsonProperty.Access.WRITE_ONLY;
 import static com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY;
 import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME;
 import static java.util.Collections.singletonList;
@@ -32,8 +35,10 @@ import javax.validation.constraints.Size;
 import java.util.List;
 
 import capital.scalable.restdocs.constraints.ConstraintReader;
+import capital.scalable.restdocs.jackson.SardObjectMapper;
 import capital.scalable.restdocs.javadoc.JavadocReader;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -62,7 +67,7 @@ public class JacksonModelAttributeSnippetTest extends AbstractSnippetTests {
 
     @Before
     public void setup() {
-        mapper = new ObjectMapper();
+        mapper = new SardObjectMapper(new ObjectMapper());
         mapper.setVisibility(mapper.getSerializationConfig().getDefaultVisibilityChecker()
                 .withFieldVisibility(JsonAutoDetect.Visibility.ANY));
         javadocReader = mock(JavadocReader.class);
@@ -172,7 +177,6 @@ public class JacksonModelAttributeSnippetTest extends AbstractSnippetTests {
                         .row("subItem2Field", "Integer", "true", "A sub item 2 field."));
     }
 
-
     @Test
     public void hasContentWithModelAttributeAnnotation() throws Exception {
         HandlerMethod handlerMethod = createHandlerMethod("addItem", Item.class);
@@ -240,6 +244,23 @@ public class JacksonModelAttributeSnippetTest extends AbstractSnippetTests {
                                 "**Deprecated.** Use index2.\n\nItem's index."));
     }
 
+    @Test
+    public void accessors() throws Exception {
+        HandlerMethod handlerMethod = createHandlerMethod("accessors", ReadWriteAccessors.class);
+
+        new JacksonModelAttributeSnippet().document(operationBuilder
+                .attribute(HandlerMethod.class.getName(), handlerMethod)
+                .attribute(ObjectMapper.class.getName(), mapper)
+                .attribute(JavadocReader.class.getName(), javadocReader)
+                .attribute(ConstraintReader.class.getName(), constraintReader)
+                .build());
+
+        assertThat(this.generatedSnippets.snippet(AUTO_MODELATTRIBUTE)).is(
+                tableWithHeader("Parameter", "Type", "Optional", "Description")
+                        .row("writeOnly", "String", "true", "")
+                        .row("bothWays", "String", "true", ""));
+    }
+
     private void mockConstraintMessage(Class<?> type, String fieldName, String comment) {
         when(constraintReader.getConstraintMessages(type, fieldName))
                 .thenReturn(singletonList(comment));
@@ -292,8 +313,11 @@ public class JacksonModelAttributeSnippetTest extends AbstractSnippetTests {
             // NOOP
         }
 
-
         public void removeItem(@ModelAttribute DeprecatedItem item) {
+            // NOOP
+        }
+
+        public void accessors(@ModelAttribute ReadWriteAccessors accessors) {
             // NOOP
         }
     }
@@ -339,5 +363,13 @@ public class JacksonModelAttributeSnippetTest extends AbstractSnippetTests {
 
     private static class SubItem2 extends ParentItem {
         private Integer subItem2Field;
+    }
+
+    private static class ReadWriteAccessors {
+        @JsonProperty(access = READ_ONLY)
+        private String readOnly;
+        @JsonProperty(access = WRITE_ONLY)
+        private String writeOnly;
+        private String bothWays;
     }
 }

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippetTest.java
@@ -2,14 +2,14 @@
  * #%L
  * Spring Auto REST Docs Core
  * %%
- * Copyright (C) 2015 - 2019 Scalable Capital GmbH
+ * Copyright (C) 2015 - 2020 Scalable Capital GmbH
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import capital.scalable.restdocs.constraints.ConstraintReader;
+import capital.scalable.restdocs.jackson.SardObjectMapper;
 import capital.scalable.restdocs.javadoc.JavadocReader;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -83,7 +84,9 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
 
     @Before
     public void setup() {
-        mapper = new ObjectMapper();
+        // SardObjectMapper doesn't really matter here as we're using serializer logic
+        // which skips WRITE_ONLY fields automatically
+        mapper = new SardObjectMapper(new ObjectMapper());
         mapper.setVisibility(mapper.getSerializationConfig().getDefaultVisibilityChecker()
                 .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
                 .withGetterVisibility(JsonAutoDetect.Visibility.ANY));

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/payload/JacksonResponseFieldSnippetTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,10 +19,13 @@
  */
 package capital.scalable.restdocs.payload;
 
+import static capital.scalable.restdocs.SnippetRegistry.AUTO_REQUEST_FIELDS;
 import static capital.scalable.restdocs.SnippetRegistry.AUTO_RESPONSE_FIELDS;
 import static capital.scalable.restdocs.payload.TableWithPrefixMatcher.tableWithPrefix;
 import static capital.scalable.restdocs.util.FormatUtil.fixLineSeparator;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
+import static com.fasterxml.jackson.annotation.JsonProperty.Access.READ_ONLY;
+import static com.fasterxml.jackson.annotation.JsonProperty.Access.WRITE_ONLY;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -44,6 +47,7 @@ import capital.scalable.restdocs.javadoc.JavadocReader;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
@@ -433,7 +437,7 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
     }
 
     @Test
-    public void genericSuperMethodCollection() throws Exception{
+    public void genericSuperMethodCollection() throws Exception {
         HandlerMethod handlerMethod = createHandlerMethod("getItemsGeneric");
         mockFieldComment(Item.class, "field1", "A string");
         mockFieldComment(Item.class, "field2", "A decimal");
@@ -471,6 +475,22 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
                         .row("field2", "Decimal", "true", "A decimal."));
     }
 
+    @Test
+    public void accessors() throws Exception {
+        HandlerMethod handlerMethod = createHandlerMethod("accessors");
+
+        new JacksonResponseFieldSnippet().document(operationBuilder
+                .attribute(HandlerMethod.class.getName(), handlerMethod)
+                .attribute(ObjectMapper.class.getName(), mapper)
+                .attribute(JavadocReader.class.getName(), javadocReader)
+                .attribute(ConstraintReader.class.getName(), constraintReader)
+                .build());
+
+        assertThat(this.generatedSnippets.snippet(AUTO_RESPONSE_FIELDS)).is(
+                tableWithHeader("Path", "Type", "Optional", "Description")
+                        .row("readOnly", "String", "true", "")
+                        .row("bothWays", "String", "true", ""));
+    }
 
     private void mockConstraintMessage(Class<?> type, String fieldName, String comment) {
         when(constraintReader.getConstraintMessages(type, fieldName))
@@ -522,7 +542,7 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
         List<T> getItemsGeneric();
     }
 
-    public static abstract class GenericTestResource<E> implements IGenericTestResource<E>{
+    public static abstract class GenericTestResource<E> implements IGenericTestResource<E> {
 
         abstract E createGeneric();
 
@@ -537,7 +557,7 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
     }
 
     // actual method responses do not matter, they are here just for the illustration
-    private static class TestResource extends GenericTestResource<Item>{
+    private static class TestResource extends GenericTestResource<Item> {
 
         @Override
         Item createGeneric() {
@@ -601,6 +621,10 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
             response.embed("commented", new CommentedItem());
             response.add(linkTo(methodOn(TestResource.class).getItem()).withSelfRel());
             return response;
+        }
+
+        public ReadWriteAccessors accessors() {
+            return new ReadWriteAccessors();
         }
     }
 
@@ -708,5 +732,13 @@ public class JacksonResponseFieldSnippetTest extends AbstractSnippetTests {
                 embedded.add(wrapper.wrap(resource, rel));
             }
         }
+    }
+
+    private static class ReadWriteAccessors {
+        @JsonProperty(access = READ_ONLY)
+        private String readOnly;
+        @JsonProperty(access = WRITE_ONLY)
+        private String writeOnly;
+        private String bothWays;
     }
 }


### PR DESCRIPTION
Fixes #142

After much hacking, I'm able to overwrite default class inspector, so that no field is skipped by default and skip logic is then manually handled in our FieldDocumentationObjectVisitor. Works both ways!