### PR TITLE
KDoc: Add support for bold, italics, and code

### DIFF
--- a/samples/java-webmvc/generated-docs/index.html
+++ b/samples/java-webmvc/generated-docs/index.html
@@ -1109,10 +1109,13 @@ Content-Length: 598
 <p><code>POST /items</code></p>
 </div>
 <div class="paragraph">
-<p>Adds new item.</p>
+<p>Adds a new <strong>item</strong>.</p>
 </div>
 <div class="paragraph">
-<p>An example of accepting a custom type as request body and returning a {@link ResponseEntity}.</p>
+<p>An <em>example</em> of accepting a custom type as request body and returning a {@link ResponseEntity}.</p>
+</div>
+<div class="paragraph">
+<p><code>someCode("foo")</code>.</p>
 </div>
 <div class="sect3">
 <h4 id="_authorization_3"><a class="anchor" href="#_authorization_3"></a><a class="link" href="#_authorization_3">2.3.1. Authorization</a></h4>
@@ -1236,7 +1239,7 @@ Size must be between 0 and 1000 inclusive.</p></td>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items' -i -X POST \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer 0b765e43-cb96-4f00-b747-af7e62590e11' \
+    -H 'Authorization: Bearer 5f5cb4c9-67a4-44da-bf06-e7d299ed9287' \
     -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
@@ -1539,7 +1542,7 @@ Must be at most 10.</p></td>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X PUT \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer 0b765e43-cb96-4f00-b747-af7e62590e11' \
+    -H 'Authorization: Bearer 5f5cb4c9-67a4-44da-bf06-e7d299ed9287' \
     -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
@@ -1663,7 +1666,7 @@ Item must exist.</p>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X DELETE \
-    -H 'Authorization: Bearer 0b765e43-cb96-4f00-b747-af7e62590e11'</code></pre>
+    -H 'Authorization: Bearer 5f5cb4c9-67a4-44da-bf06-e7d299ed9287'</code></pre>
 </div>
 </div>
 </div>
@@ -2228,6 +2231,8 @@ Content-Length: 1072
   "totalElements" : 1,
   "last" : true,
   "size" : 20,
+  "numberOfElements" : 1,
+  "first" : true,
   "number" : 0,
   "sort" : {
     "orders" : [ ],
@@ -2235,8 +2240,6 @@ Content-Length: 1072
     "unsorted" : true,
     "empty" : true
   },
-  "numberOfElements" : 1,
-  "first" : true,
   "empty" : false
 }</code></pre>
 </div>
@@ -3527,7 +3530,7 @@ Content-Length: 459
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2020-02-10 13:59:32 +0100
+Last updated 2020-04-12 14:15:02 +0200
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/styles/github.min.css">

--- a/samples/java-webmvc/src/main/java/capital/scalable/restdocs/example/items/ItemResource.java
+++ b/samples/java-webmvc/src/main/java/capital/scalable/restdocs/example/items/ItemResource.java
@@ -108,9 +108,11 @@ public class ItemResource {
     }
 
     /**
-     * Adds new item.
+     * Adds a new <b>item</b>.
      * <p>
-     * An example of accepting a custom type as request body and returning a {@link ResponseEntity}.
+     * An <i>example</i> of accepting a custom type as request body and returning a {@link ResponseEntity}.
+     * <p>
+     * <code>someCode("foo")</code>
      *
      * @param itemUpdate Item information
      * @return response

--- a/samples/kotlin-webmvc/generated-docs/index.html
+++ b/samples/kotlin-webmvc/generated-docs/index.html
@@ -1073,10 +1073,13 @@ Content-Length: 598
 <p><code>POST /items</code></p>
 </div>
 <div class="paragraph">
-<p>Adds new item.</p>
+<p>Adds a new <strong>item</strong>.</p>
 </div>
 <div class="paragraph">
-<p>An example of accepting a custom type as request body and returning a ResponseEntity.</p>
+<p>An <em>example</em> of accepting a custom type as request body and returning a ResponseEntity.</p>
+</div>
+<div class="paragraph">
+<p><code>someCode("foo")</code></p>
 </div>
 <div class="sect3">
 <h4 id="_authorization_3"><a class="anchor" href="#_authorization_3"></a><a class="link" href="#_authorization_3">2.3.1. Authorization</a></h4>
@@ -1186,7 +1189,7 @@ Size must be between 0 and 1000 inclusive.</p></td>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items' -i -X POST \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer e75106d3-5eb2-456f-9d98-f0d516990b01' \
+    -H 'Authorization: Bearer 81c803fa-adc9-4c33-8d7f-d460882862a3' \
     -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
@@ -1468,7 +1471,7 @@ Must be at most 10.</p></td>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X PUT \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer e75106d3-5eb2-456f-9d98-f0d516990b01' \
+    -H 'Authorization: Bearer 81c803fa-adc9-4c33-8d7f-d460882862a3' \
     -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
@@ -1576,7 +1579,7 @@ Content-Length: 124
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X DELETE \
-    -H 'Authorization: Bearer e75106d3-5eb2-456f-9d98-f0d516990b01'</code></pre>
+    -H 'Authorization: Bearer 81c803fa-adc9-4c33-8d7f-d460882862a3'</code></pre>
 </div>
 </div>
 </div>
@@ -2089,22 +2092,22 @@ Content-Length: 1072
     "offset" : 0,
     "pageNumber" : 0,
     "pageSize" : 20,
-    "paged" : true,
-    "unpaged" : false
+    "unpaged" : false,
+    "paged" : true
   },
   "total" : 1,
+  "totalElements" : 1,
   "totalPages" : 1,
   "last" : true,
-  "totalElements" : 1,
   "size" : 20,
-  "numberOfElements" : 1,
+  "number" : 0,
   "sort" : {
     "orders" : [ ],
     "sorted" : false,
     "unsorted" : true,
     "empty" : true
   },
-  "number" : 0,
+  "numberOfElements" : 1,
   "first" : true,
   "empty" : false
 }</code></pre>
@@ -2766,7 +2769,7 @@ Content-Length: 459
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2020-02-10 13:52:46 +0100
+Last updated 2020-04-12 14:15:02 +0200
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/styles/github.min.css">

--- a/samples/kotlin-webmvc/src/main/java/capital/scalable/restdocs/example/items/ItemResource.kt
+++ b/samples/kotlin-webmvc/src/main/java/capital/scalable/restdocs/example/items/ItemResource.kt
@@ -85,10 +85,11 @@ internal class ItemResource {
     fun allItems() = arrayOf(ITEM, CHILD)
 
     /**
-     * Adds new item.
+     * Adds a new **item**.
      *
+     * An *example* of accepting a custom type as request body and returning a [ResponseEntity].
      *
-     * An example of accepting a custom type as request body and returning a [ResponseEntity].
+     * `someCode("foo")`
      *
      * @param itemUpdate Item information
      * @return response

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/javadoc/JavadocUtil.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/javadoc/JavadocUtil.java
@@ -45,8 +45,12 @@ public class JavadocUtil {
                 .replace("</li>", "")
                 .replace("<b>", templateFormatting.getBold())
                 .replace("</b>", templateFormatting.getBold())
+                .replace("<strong>", templateFormatting.getBold())
+                .replace("</strong>", templateFormatting.getBold())
                 .replace("<i>", templateFormatting.getItalics())
                 .replace("</i>", templateFormatting.getItalics())
+                .replace("<em>", templateFormatting.getItalics())
+                .replace("</em>", templateFormatting.getItalics())
                 .replace("<code>", templateFormatting.getCode())
                 .replace("</code>", templateFormatting.getCode())
                 .replaceAll("<a\\s+href\\s*=\\s*[\"\'](.*?)[\"\']\\s*>(.*?)</a>",

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/javadoc/JavadocUtil.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/javadoc/JavadocUtil.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -47,6 +47,8 @@ public class JavadocUtil {
                 .replace("</b>", templateFormatting.getBold())
                 .replace("<i>", templateFormatting.getItalics())
                 .replace("</i>", templateFormatting.getItalics())
+                .replace("<code>", templateFormatting.getCode())
+                .replace("</code>", templateFormatting.getCode())
                 .replaceAll("<a\\s+href\\s*=\\s*[\"\'](.*?)[\"\']\\s*>(.*?)</a>",
                         templateFormatting.link());
 

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/util/TemplateFormatting.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/util/TemplateFormatting.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,24 +26,28 @@ public class TemplateFormatting {
     private static final String BOLD_MD = "**";
     private static final String ITALICS_ADOC = "__";
     private static final String ITALICS_MD = "*";
+    private static final String CODE_ADOC = "`";
+    private static final String CODE_MD = "`";
     private static final String LINK_ADOC = "link:$1[$2]";
     private static final String LINK_MD = "[$2]($1)";
 
     public static TemplateFormatting ASCIIDOC =
-            new TemplateFormatting(LINE_BREAK_ADOC, BOLD_ADOC, ITALICS_ADOC, LINK_ADOC);
+            new TemplateFormatting(LINE_BREAK_ADOC, BOLD_ADOC, ITALICS_ADOC, CODE_ADOC, LINK_ADOC);
 
     public static TemplateFormatting MARKDOWN =
-            new TemplateFormatting(LINE_BREAK_MD, BOLD_MD, ITALICS_MD, LINK_MD);
+            new TemplateFormatting(LINE_BREAK_MD, BOLD_MD, ITALICS_MD, CODE_MD, LINK_MD);
 
     private final String lineBreak;
     private final String bold;
     private final String italics;
+    private final String code;
     private final String link;
 
-    private TemplateFormatting(String lineBreak, String bold, String italics, String link) {
+    private TemplateFormatting(String lineBreak, String bold, String italics, String code, String link) {
         this.lineBreak = lineBreak;
         this.bold = bold;
         this.italics = italics;
+        this.code = code;
         this.link = link;
     }
 
@@ -57,6 +61,10 @@ public class TemplateFormatting {
 
     public String getItalics() {
         return italics;
+    }
+
+    public String getCode() {
+        return code;
     }
 
     public String link() {

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/javadoc/JavadocUtilTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/javadoc/JavadocUtilTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -109,16 +109,16 @@ public class JavadocUtilTest {
 
     @Test
     public void convertStylingAsciidoc() {
-        String actual = "<b>bold</b>normal<i>italics</i>";
-        String expected = "**bold**normal__italics__";
+        String actual = "<b>bold</b>normal<i>italics</i><code>code()</code>";
+        String expected = "**bold**normal__italics__`code()`";
         assertThat(JavadocUtil.convertFromJavadoc(actual, TemplateFormatting.ASCIIDOC),
                 is(expected));
     }
 
     @Test
     public void convertStylingMarkdown() {
-        String actual = "<b>bold</b>normal<i>italics</i>";
-        String expected = "**bold**normal*italics*";
+        String actual = "<b>bold</b>normal<i>italics</i><code>code()</code>";
+        String expected = "**bold**normal*italics*`code()`";
         assertThat(JavadocUtil.convertFromJavadoc(actual, TemplateFormatting.MARKDOWN),
                 is(expected));
     }

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/javadoc/JavadocUtilTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/javadoc/JavadocUtilTest.java
@@ -108,17 +108,49 @@ public class JavadocUtilTest {
     }
 
     @Test
-    public void convertStylingAsciidoc() {
-        String actual = "<b>bold</b>normal<i>italics</i><code>code()</code>";
-        String expected = "**bold**normal__italics__`code()`";
+    public void convertBoldStylingAsciidoc() {
+        String actual = "before<b>bold</b>normal<strong>bold2</strong>after";
+        String expected = "before**bold**normal**bold2**after";
         assertThat(JavadocUtil.convertFromJavadoc(actual, TemplateFormatting.ASCIIDOC),
                 is(expected));
     }
 
     @Test
-    public void convertStylingMarkdown() {
-        String actual = "<b>bold</b>normal<i>italics</i><code>code()</code>";
-        String expected = "**bold**normal*italics*`code()`";
+    public void convertItalicsStylingAsciidoc() {
+        String actual = "before<i>italics</i>normal<em>italics2</em>after";
+        String expected = "before__italics__normal__italics2__after";
+        assertThat(JavadocUtil.convertFromJavadoc(actual, TemplateFormatting.ASCIIDOC),
+                is(expected));
+    }
+
+    @Test
+    public void convertCodeStylingAsciidoc() {
+        String actual = "before <code>code()</code> after";
+        String expected = "before `code()` after";
+        assertThat(JavadocUtil.convertFromJavadoc(actual, TemplateFormatting.ASCIIDOC),
+                is(expected));
+    }
+
+    @Test
+    public void convertBoldStylingMarkdown() {
+        String actual = "before<b>bold</b>normal<strong>bold2</strong>after";
+        String expected = "before**bold**normal**bold2**after";
+        assertThat(JavadocUtil.convertFromJavadoc(actual, TemplateFormatting.MARKDOWN),
+                is(expected));
+    }
+
+    @Test
+    public void convertItalicsStylingMarkdown() {
+        String actual = "before<i>italics</i>normal<em>italics2</em>after";
+        String expected = "before*italics*normal*italics2*after";
+        assertThat(JavadocUtil.convertFromJavadoc(actual, TemplateFormatting.MARKDOWN),
+                is(expected));
+    }
+
+    @Test
+    public void convertCodeStylingMarkdown() {
+        String actual = "before <code>code()</code> after";
+        String expected = "before `code()` after";
         assertThat(JavadocUtil.convertFromJavadoc(actual, TemplateFormatting.MARKDOWN),
                 is(expected));
     }

--- a/spring-auto-restdocs-dokka-json/src/main/kotlin/capital/scalable/dokka/json/JsonFormatService.kt
+++ b/spring-auto-restdocs-dokka-json/src/main/kotlin/capital/scalable/dokka/json/JsonFormatService.kt
@@ -127,9 +127,13 @@ open class JsonOutputBuilder(
     private fun extractContent(content: ContentNode, topLevel: Boolean): String {
         when (content) {
             is ContentText -> return content.text
+            is ContentEmphasis -> return wrap("<i>", "</i>", joinChildren(content))
+            is ContentStrong -> return wrap("<b>", "</b>", joinChildren(content))
+            is ContentCode -> return wrap("<code>", "</code>", joinChildren(content))
             is ContentUnorderedList -> return wrap("<ul>", "</ul>", joinChildren(content))
             is ContentListItem -> return listItem(content)
             is ContentParagraph -> return paragraph(content, topLevel)
+            is ContentSection -> return paragraph(content, topLevel)
             is ContentExternalLink -> return "<a href=\"${content.href}\">${joinChildren(content)}</a>"
             // Ignore href of references to other code parts and just show the link text, e.g. class name.
             is ContentNodeLink -> return joinChildren(content)
@@ -137,12 +141,14 @@ open class JsonOutputBuilder(
             // thus this one has to be after them.
             is ContentBlock -> return joinChildren(content)
             is ContentEmpty -> return ""
+            is ContentSymbol -> return ""
+            is NodeRenderContent -> return ""
             else -> logger.warn("Unhandled content node: $content")
         }
         return ""
     }
 
-    private fun paragraph(paragraph: ContentParagraph, topLevel: Boolean): String {
+    private fun paragraph(paragraph: ContentBlock, topLevel: Boolean): String {
         return if (topLevel) {
             // Ignore paragraphs on the top level
             joinChildren(paragraph)

--- a/spring-auto-restdocs-dokka-json/testdata/JavaClass.java
+++ b/spring-auto-restdocs-dokka-json/testdata/JavaClass.java
@@ -4,7 +4,7 @@ import java.math.BigDecimal;
  * Javadoc on a Java class
  * <p>
  * Next paragraph
- *
+ * UTF 8 test: 我能吞下玻璃而不伤身体。Árvíztűrő tükörfúrógép
  * <ul>
  *     <li>Item 1</li>
  *     <li>Item 2</li>

--- a/spring-auto-restdocs-dokka-json/testdata/JavaClass.json
+++ b/spring-auto-restdocs-dokka-json/testdata/JavaClass.json
@@ -1,5 +1,5 @@
 {
-  "comment" : "Javadoc on a Java class<p>Next paragraph</p><ul><li>Item 1</li> <li>Item 2</li></ul>",
+  "comment" : "Javadoc on a Java class<p>Next paragraph UTF 8 test: 我能吞下玻璃而不伤身体。Árvíztűrő tükörfúrógép</p><ul><li>Item 1</li> <li>Item 2</li></ul>",
   "fields" : {
     "someField" : {
       "comment" : "A Java field",

--- a/spring-auto-restdocs-dokka-json/testdata/KotlinDataClass.NestedClass.json
+++ b/spring-auto-restdocs-dokka-json/testdata/KotlinDataClass.NestedClass.json
@@ -1,8 +1,8 @@
 {
-  "comment" : "A nested class",
+  "comment" : "A nested class<p><code>There is a literal backtick (`) here.</code></p>",
   "fields" : {
     "someField" : {
-      "comment" : "Field on a nested class",
+      "comment" : "Field on a nested class with some code: <code>println(\"foo\")</code>",
       "tags" : { }
     }
   },

--- a/spring-auto-restdocs-dokka-json/testdata/KotlinDataClass.json
+++ b/spring-auto-restdocs-dokka-json/testdata/KotlinDataClass.json
@@ -1,28 +1,28 @@
 {
-  "comment" : "Class documentation<p>Next paragraph</p><ul><li>Item 1</li><li>Item 2</li></ul>",
+  "comment" : "Class documentation<p>Next paragraph\nUTF 8 test: 我能吞下玻璃而不伤身体。Árvíztűrő tükörfúrógép</p><ul><li>Item 1</li><li>Item 2</li></ul>",
   "fields" : {
     "text" : {
-      "comment" : "Documentation for text property",
+      "comment" : "Documentation for <i>text</i> property (テスト)",
       "tags" : {
         "see" : "KotlinDataClass",
-        "deprecated" : "Use something else",
+        "deprecated" : "Use something else (テスト)",
         "title" : "Custom tag"
       }
     },
     "number" : {
-      "comment" : "Documentation for number property",
+      "comment" : "Documentation for <i>number</i> property",
       "tags" : { }
     }
   },
   "methods" : {
     "add" : {
-      "comment" : "Function add<p><a href=\"http://some-url.com\">some link</a></p>",
+      "comment" : "Function add (テスト)<p><a href=\"http://some-url.com\">some link</a></p>",
       "parameters" : {
-        "a" : "First param a",
-        "b" : "Second param b"
+        "a" : "First param <b>a</b>",
+        "b" : "Second param <b>b</b>"
       },
       "tags" : {
-        "parameters" : "Second param b",
+        "parameters" : "Second param <b>b</b>",
         "see" : "KotlinDataClass",
         "deprecated" : "Use something else",
         "title" : "Custom tag"

--- a/spring-auto-restdocs-dokka-json/testdata/KotlinDataClass.kt
+++ b/spring-auto-restdocs-dokka-json/testdata/KotlinDataClass.kt
@@ -6,31 +6,32 @@ import java.math.BigDecimal
  * Class documentation
  *
  * Next paragraph
+ * UTF 8 test: 我能吞下玻璃而不伤身体。Árvíztűrő tükörfúrógép
  *
  * * Item 1
  * * Item 2
  */
 data class KotlinDataClass(
         /**
-         * Documentation for text property
+         * Documentation for _text_ property (テスト)
          *
          * @see KotlinDataClass
-         * @deprecated Use something else
+         * @deprecated Use something else (テスト)
          * @title Custom tag
          */
         val text: String,
         /**
-         * Documentation for number property
+         * Documentation for *number* property
          */
         val number: BigDecimal) {
 
     /**
-     * Function add
+     * Function add (テスト)
      *
      * [some link](http://some-url.com)
      *
-     * @param a First param a
-     * @param b Second param b
+     * @param a First param **a**
+     * @param b Second param __b__
      * @see KotlinDataClass
      * @deprecated Use something else
      * @title Custom tag
@@ -39,10 +40,12 @@ data class KotlinDataClass(
 
     /**
      * A nested class
+     *
+     * ``There is a literal backtick (`) here.``
      */
     data class NestedClass(
             /**
-             * Field on a nested class
+             * Field on a nested class with some code: `println("foo")`
              */
             val someField: String)
 }


### PR DESCRIPTION
KDoc support for
* italics: `_like this_` or `*like this*`
* bold: `__like this__` or `**like this**`
* code: `` `call()` ``

Core:
* `<strong>` and `<em>` are often used on documentation and initially I also used them in our Dokka extension because that is what Dokka uses internally when converting. It's also the result when converting Asciidoc to HTML.
* Handle `<strong>` like `<b>`
* Handle `<em>` like `<i>`

In addition, avoid tow handled node warnings and handle sections like paragraphs. Also test the UTF-8 support.