### PR TITLE
Update sample projects to Spring Boot 2.3.0

### DIFF
--- a/samples/java-webflux/pom.xml
+++ b/samples/java-webflux/pom.xml
@@ -50,6 +50,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>
         <dependency>

--- a/samples/java-webflux/pom.xml
+++ b/samples/java-webflux/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.6.RELEASE</version>
+        <version>2.3.0.RELEASE</version>
         <relativePath/>
     </parent>
 
@@ -145,7 +145,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.2.4.RELEASE</version>
+                <version>2.3.0.RELEASE</version>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/samples/java-webmvc/build.gradle
+++ b/samples/java-webmvc/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext {
         springAutoRestDocsVersion = "2.0.9-SNAPSHOT"
         springRestDocsVersion = "2.0.4.RELEASE"
-        springBootVersion = "2.2.6.RELEASE"
+        springBootVersion = "2.3.0.RELEASE"
     }
     repositories {
         jcenter()

--- a/samples/java-webmvc/build.gradle
+++ b/samples/java-webmvc/build.gradle
@@ -47,6 +47,7 @@ repositories {
 
 dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web"
+    implementation "org.springframework.boot:spring-boot-starter-validation"
     implementation "org.springframework.boot:spring-boot-starter-security"
     implementation "org.springframework.security.oauth:spring-security-oauth2:2.3.5.RELEASE"
     implementation "org.springframework.data:spring-data-commons"

--- a/samples/java-webmvc/pom.xml
+++ b/samples/java-webmvc/pom.xml
@@ -50,6 +50,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>

--- a/samples/java-webmvc/pom.xml
+++ b/samples/java-webmvc/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.6.RELEASE</version>
+        <version>2.3.0.RELEASE</version>
         <relativePath/>
     </parent>
 
@@ -158,7 +158,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.2.4.RELEASE</version>
+                <version>2.3.0.RELEASE</version>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/samples/kotlin-webmvc/build.gradle
+++ b/samples/kotlin-webmvc/build.gradle
@@ -1,9 +1,9 @@
 buildscript {
     ext {
-        kotlinVersion = "1.3.71"
+        kotlinVersion = "1.3.72"
         springAutoRestDocsVersion = "2.0.9-SNAPSHOT"
         springRestDocsVersion = "2.0.4.RELEASE"
-        springBootVersion = "2.2.6.RELEASE"
+        springBootVersion = "2.3.0.RELEASE"
         dokkaPluginVersion = "0.10.1"
     }
     repositories {

--- a/samples/kotlin-webmvc/build.gradle
+++ b/samples/kotlin-webmvc/build.gradle
@@ -55,6 +55,7 @@ repositories {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     implementation "org.springframework.boot:spring-boot-starter-web"
+    implementation "org.springframework.boot:spring-boot-starter-validation"
     implementation "org.springframework.boot:spring-boot-starter-security"
     implementation "org.springframework.security.oauth:spring-security-oauth2:2.3.5.RELEASE"
     implementation "org.springframework.data:spring-data-commons"

--- a/samples/kotlin-webmvc/pom.xml
+++ b/samples/kotlin-webmvc/pom.xml
@@ -52,6 +52,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>

--- a/samples/kotlin-webmvc/pom.xml
+++ b/samples/kotlin-webmvc/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.6.RELEASE</version>
+        <version>2.3.0.RELEASE</version>
         <relativePath/>
     </parent>
 
@@ -35,7 +35,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring-restdocs.version>2.0.4.RELEASE</spring-restdocs.version>
         <spring-auto-restdocs.version>2.0.9-SNAPSHOT</spring-auto-restdocs.version>
-        <kotlin.version>1.3.71</kotlin.version>
+        <kotlin.version>1.3.72</kotlin.version>
         <dokka.version>0.10.1</dokka.version>
         <jsonDirectory>${project.build.directory}/generated-javadoc-json</jsonDirectory>
     </properties>

--- a/samples/shared/pom.xml
+++ b/samples/shared/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.6.RELEASE</version>
+        <version>2.3.0.RELEASE</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
Upgrade guide: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.3-Release-Notes#upgrading-from-spring-boot-22

Only relevant change: "Web and WebFlux starters do not depend on the validation starter by default anymore. If your application is using validation features, for example you find that javax.validation.* imports are not being resolved, you’ll need to add the starter yourself."