### PR TITLE
2.0.9 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ from the Introducing Spring Auto REST Docs talk at Spring IO 2017 are also avail
 
 ## Documentation
 
-[Current 2.0.8 release](https://htmlpreview.github.io/?https://github.com/ScaCap/spring-auto-restdocs/blob/v2.0.8/docs/index.html) reference guide (based on Spring REST Docs 2.x).
+[Current 2.0.9 release](https://htmlpreview.github.io/?https://github.com/ScaCap/spring-auto-restdocs/blob/v2.0.9/docs/index.html) reference guide (based on Spring REST Docs 2.x).
 
 [Current 1.0.15 release](https://htmlpreview.github.io/?https://github.com/ScaCap/spring-auto-restdocs/blob/v1.0.15/docs/index.html) reference guide (based on Spring REST Docs 1.x).
 
-Latest master [2.0.8](https://scacap.github.io/spring-auto-restdocs) reference guide.
+Latest master [2.0.9](https://scacap.github.io/spring-auto-restdocs) reference guide.
 
 Older releases:
-[2.0.7](https://htmlpreview.github.io/?https://github.com/ScaCap/spring-auto-restdocs/blob/v2.0.7/docs/index.html),
+[2.0.8](https://htmlpreview.github.io/?https://github.com/ScaCap/spring-auto-restdocs/blob/v2.0.8/docs/index.html),
 [1.0.14](https://htmlpreview.github.io/?https://github.com/ScaCap/spring-auto-restdocs/blob/v1.0.14/docs/index.html)
 
 ## Main features

--- a/docs/index.html
+++ b/docs/index.html
@@ -437,7 +437,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <h1>Spring Auto REST Docs</h1>
 <div class="details">
 <span id="author" class="author">Scalable Capital</span><br>
-<span id="revnumber">version 2.0.9-SNAPSHOT</span>
+<span id="revnumber">version 2.0.9</span>
 </div>
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
@@ -496,6 +496,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </li>
 <li><a href="#contributing">Contributing</a>
 <ul class="sectlevel2">
+<li><a href="#contributing-pr">Pull Requests</a></li>
 <li><a href="#contributing-building">Building from source</a></li>
 </ul>
 </li>
@@ -605,6 +606,10 @@ in your setup. You might have to remove <code>dependsOn test</code> depending on
 <p><em>Is HATEOAS supported?</em></p>
 <p>Yes, there is basic support for <a href="#snippets-links">links</a> and <a href="#snippets-embedded">embedded</a> resources.</p>
 </li>
+<li>
+<p><em>What should I do if I get a <code>NoSuchBeanDefinitionException: No bean named 'webHandler' available</code> exception?</em></p>
+<p>This means that the servlet stack instead if the reactive one is active. Make sure that <code>@EnableWebFlux</code> is used.</p>
+</li>
 </ol>
 </div>
 </div>
@@ -620,7 +625,7 @@ in your setup. You might have to remove <code>dependsOn test</code> depending on
 <div class="ulist">
 <ul>
 <li>
-<p>Java 8 or Kotlin 1.2</p>
+<p>Java 8 or Kotlin 1.3</p>
 </li>
 <li>
 <p>Spring REST Docs 2.0.4.RELEASE (see <a href="http://docs.spring.io/spring-restdocs/docs/2.0.4.RELEASE/reference/html5/">documentation</a>)</p>
@@ -635,7 +640,9 @@ in your setup. You might have to remove <code>dependsOn test</code> depending on
 please use the 1.0.x version of Spring Auto REST Docs.</p>
 </div>
 <div class="paragraph">
-<p>For Java 9/10/11 support, use <code>spring-auto-restdocs-json-doclet-jdk9</code> as doclet dependency.</p>
+<p>For Java 9+ support, use <code>spring-auto-restdocs-json-doclet-jdk9</code> as doclet dependency.
+Our support is focused on the latest Kotlin version, Java 8 and 11.
+In addition, we try to support the latest Java version that is supported by Spring.</p>
 </div>
 </div>
 <div class="sect2">
@@ -1366,7 +1373,9 @@ include::auto-description.adoc[]
 
 ==== {{header}}
 
-include::{{fileName}}.adoc[]
+{{#filenames}}
+include::{{.}}.adoc[]
+{{/filenames}}
 {{/sections}}</code></pre>
 </div>
 </div>
@@ -1795,7 +1804,9 @@ include::auto-description.adoc[]
 
 ==== {{header}}
 
-include::{{fileName}}.adoc[]
+{{#filenames}}
+include::{{.}}.adoc[]
+{{/filenames}}
 {{/sections}}</code></pre>
 </div>
 </div>
@@ -2436,13 +2447,19 @@ and thus has to be registered manually.</p>
 <h2 id="contributing"><a class="link" href="#contributing">Contributing</a></h2>
 <div class="sectionbody">
 <div class="sect2">
+<h3 id="contributing-pr"><a class="link" href="#contributing-pr">Pull Requests</a></h3>
+<div class="paragraph">
+<p>For code formatting please use <a href="https://github.com/ScaCap/spring-auto-restdocs/blob/master/intellij-codestyle.xml">intellij-codestyle.xml</a>.</p>
+</div>
+</div>
+<div class="sect2">
 <h3 id="contributing-building"><a class="link" href="#contributing-building">Building from source</a></h3>
 <div class="sect3">
-<h4 id="contributing-installing-testjar"><a class="link" href="#contributing-installing-testjar">Install Spring REST Docs test JAR</a></h4>
+<h4 id="contributing-installing-restdocs-testjar"><a class="link" href="#contributing-installing-restdocs-testjar">Install Spring REST Docs test JAR</a></h4>
 <div class="paragraph">
 <p>The Spring REST Docs test JAR is not published via Maven, but this project relies on it.
 If you want to build this project yourself, you need to install the test JAR.
-The test JAR is located in the lib folder and can be installed as follow:</p>
+The test JAR is located in the lib folder and can be installed as follows:</p>
 </div>
 <div class="listingblock">
 <div class="title">Bash</div>
@@ -2454,7 +2471,23 @@ The test JAR is located in the lib folder and can be installed as follow:</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="contributing-building-testjar"><a class="link" href="#contributing-building-testjar">Build Spring REST Docs test JAR</a></h4>
+<h4 id="contributing-installing-dokka-testjar"><a class="link" href="#contributing-installing-dokka-testjar">Install Dokka Core test JAR</a></h4>
+<div class="paragraph">
+<p>Dokka publishes no test JAR, but the Spring Auto REST Docs Dokka extension uses their test utilities.
+If you want to build this project yourself, you need to install the test JAR.
+The test JAR is located in the lib folder and can be installed as follows:</p>
+</div>
+<div class="listingblock">
+<div class="title">Bash</div>
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">mvn install:install-file -Dfile=lib/dokka-core-0.10.1-tests.jar \
+     -DgroupId=org.jetbrains.dokka -DartifactId=dokka-core -Dversion=0.10.1 \
+     -Dpackaging=jar -Dclassifier=test</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="contributing-building-restdocs-testjar"><a class="link" href="#contributing-building-restdocs-testjar">Build Spring REST Docs test JAR</a></h4>
 <div class="paragraph">
 <p>Building the Spring REST Docs test JAR is not required to build the project,
 but if you ever want to upgrade the version of Spring REST Docs in this project this step has to be done.</p>
@@ -2497,6 +2530,56 @@ and has to be installed with the Maven command shown in the section above.</p>
 </div>
 </div>
 <div class="sect3">
+<h4 id="contributing-building-dokka-testjar"><a class="link" href="#contributing-building-dokka-testjar">Build Dokka Core test JAR</a></h4>
+<div class="paragraph">
+<p>Building the Dokka core test JAR is not required to build the project,
+but if you ever want to upgrade the version of Dokka in this project this step has to be done.</p>
+</div>
+<div class="paragraph">
+<p>We use version 0.10.1 of Dokka in this example.</p>
+</div>
+<div class="paragraph">
+<p>Clone and checkout a specific version of Dokka:</p>
+</div>
+<div class="listingblock">
+<div class="title">Bash</div>
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">git clone git@github.com:Kotlin/dokka.git
+cd dokka
+git checkout 0.10.1</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Add the following snippet at the end of <code>core/build.gradle</code>:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-groovy hljs" data-lang="groovy">task testJar(type: Jar) {
+    classifier = 'tests'
+    from sourceSets.test.output
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>To speed the build up and avoid test issues, once can reduce the list of sub-projects in
+<code>settings.gradle</code> to just <code>core</code> and <code>integration</code>.</p>
+</div>
+<div class="paragraph">
+<p>Make sure to use JDK 8 for the build.
+Create the test JAR by running the following command on the top-level:</p>
+</div>
+<div class="listingblock">
+<div class="title">Bash</div>
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">./gradlew testJar</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Afterwards the test JAR is located at
+<code>core/build/libs/core-0.10.1-SNAPSHOT-tests.jar</code></p>
+</div>
+</div>
+<div class="sect3">
 <h4 id="contributing-building-build"><a class="link" href="#contributing-building-build">Build</a></h4>
 <div class="listingblock">
 <div class="title">Bash (in root folder)</div>
@@ -2511,8 +2594,8 @@ and has to be installed with the Maven command shown in the section above.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version 2.0.9-SNAPSHOT<br>
-Last updated 2020-03-29 23:43:30 +0200
+Version 2.0.9<br>
+Last updated 2020-08-07 14:01:18 +0200
 </div>
 </div>
 <link rel="stylesheet" href="highlight/styles/github.min.css">

--- a/docs/index.html
+++ b/docs/index.html
@@ -660,7 +660,7 @@ In addition, we try to support the latest Java version that is supported by Spri
 <pre class="highlightjs highlight"><code class="language-xml hljs" data-lang="xml">&lt;dependency&gt;
     &lt;groupId&gt;capital.scalable&lt;/groupId&gt;
     &lt;artifactId&gt;spring-auto-restdocs-core&lt;/artifactId&gt;
-    &lt;version&gt;2.0.8&lt;/version&gt;
+    &lt;version&gt;2.0.9&lt;/version&gt;
     &lt;scope&gt;test&lt;/scope&gt;
 &lt;/dependency&gt;
 
@@ -697,7 +697,7 @@ In addition, we try to support the latest Java version that is supported by Spri
                         &lt;docletArtifact&gt;
                             &lt;groupId&gt;capital.scalable&lt;/groupId&gt;
                             &lt;artifactId&gt;spring-auto-restdocs-json-doclet&lt;/artifactId&gt; <i class="conum" data-value="3"></i><b>(3)</b>
-                            &lt;version&gt;2.0.8&lt;/version&gt;
+                            &lt;version&gt;2.0.9&lt;/version&gt;
                         &lt;/docletArtifact&gt;
                         &lt;destDir&gt;generated-javadoc-json&lt;/destDir&gt; <i class="conum" data-value="2"></i><b>(2)</b>
                         &lt;reportOutputDirectory&gt;${project.build.directory}&lt;/reportOutputDirectory&gt; <i class="conum" data-value="2"></i><b>(2)</b>
@@ -742,8 +742,8 @@ ext {
 }
 
 dependencies {
-    testCompile group: 'capital.scalable', name: 'spring-auto-restdocs-core', version: '2.0.8'
-    jsondoclet group: 'capital.scalable', name: 'spring-auto-restdocs-json-doclet', version: '2.0.8' <i class="conum" data-value="3"></i><b>(3)</b>
+    testCompile group: 'capital.scalable', name: 'spring-auto-restdocs-core', version: '2.0.9'
+    jsondoclet group: 'capital.scalable', name: 'spring-auto-restdocs-json-doclet', version: '2.0.9' <i class="conum" data-value="3"></i><b>(3)</b>
 }
 
 task jsonDoclet(type: Javadoc, dependsOn: compileJava) {
@@ -2595,7 +2595,7 @@ Create the test JAR by running the following command on the top-level:</p>
 <div id="footer">
 <div id="footer-text">
 Version 2.0.9<br>
-Last updated 2020-08-07 14:01:18 +0200
+Last updated 2020-08-10 10:13:23 +0200
 </div>
 </div>
 <link rel="stylesheet" href="highlight/styles/github.min.css">

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>capital.scalable</groupId>
     <artifactId>spring-auto-restdocs-parent</artifactId>
-    <version>2.0.9-SNAPSHOT</version>
+    <version>2.0.9</version>
     <packaging>pom</packaging>
 
     <name>Spring Auto REST Docs Parent POM</name>

--- a/samples/java-webflux/pom.xml
+++ b/samples/java-webflux/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>capital.scalable</groupId>
     <artifactId>spring-auto-restdocs-java-webflux-example</artifactId>
-    <version>2.0.9-SNAPSHOT</version>
+    <version>2.0.9</version>
 
     <name>Spring Auto REST Docs Java WebFlux Example Project</name>
     <description>Example project for Spring Auto REST Docs</description>
@@ -35,7 +35,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <start-class>capital.scalable.restdocs.example.Application</start-class>
         <spring-restdocs.version>2.0.4.RELEASE</spring-restdocs.version>
-        <spring-auto-restdocs.version>2.0.9-SNAPSHOT</spring-auto-restdocs.version>
+        <spring-auto-restdocs.version>2.0.9</spring-auto-restdocs.version>
     </properties>
 
     <dependencies>

--- a/samples/java-webmvc/build.gradle
+++ b/samples/java-webmvc/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springAutoRestDocsVersion = "2.0.9-SNAPSHOT"
+        springAutoRestDocsVersion = "2.0.9"
         springRestDocsVersion = "2.0.4.RELEASE"
         springBootVersion = "2.3.0.RELEASE"
     }
@@ -20,7 +20,7 @@ apply plugin: "io.spring.dependency-management"
 apply plugin: "org.asciidoctor.convert"
 
 group = "capital.scalable"
-version = "2.0.9-SNAPSHOT"
+version = "2.0.9"
 
 description = """Spring Auto REST Docs Java Web MVC Example Project"""
 

--- a/samples/java-webmvc/generated-docs/index.html
+++ b/samples/java-webmvc/generated-docs/index.html
@@ -463,6 +463,8 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#resources-item-resource-test-clone-item">2.11. Clone Item (deprecated)</a></li>
 <li><a href="#resources-item-resource-test-get-hypermedia-item">2.12. Get Hypermedia Item</a></li>
 <li><a href="#resources-item-resource-test-get-item-as-resource">2.13. Get Item As Resource</a></li>
+<li><a href="#resources-item-resource-test-get-item-with-filter">2.14. Get Item With Filter</a></li>
+<li><a href="#resources-item-resource-test-update-item-with-filter">2.15. Update Item With Filter</a></li>
 </ul>
 </li>
 <li><a href="#resources-items-get-spring-rest-docs">3. SARD/SRD mix</a>
@@ -1146,46 +1148,6 @@ Content-Length: 598
 </colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top">Parameter</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Optional</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">description</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true<br>
-EN: false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.</p>
-<p class="tableblock">DE: Size must be between 2 and 10 inclusive.<br>
-EN: Size must be between 4 and 12 inclusive.<br>
-Length must be between 0 and 20 inclusive.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Country dependent type of the item.</p>
-<p class="tableblock">DE: Must be one of [klein, groß].<br>
-EN: Must be one of [small, big].<br>
-Size must be between 0 and 1000 inclusive.</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_request_fields_4"><a class="anchor" href="#_request_fields_4"></a><a class="link" href="#_request_fields_4">2.3.5. Request fields</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-</colgroup>
-<thead>
-<tr>
 <th class="tableblock halign-left valign-top">Path</th>
 <th class="tableblock halign-left valign-top">Type</th>
 <th class="tableblock halign-left valign-top">Optional</th>
@@ -1201,7 +1163,7 @@ EN: false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.</p>
 <p class="tableblock">DE: Size must be between 2 and 10 inclusive.<br>
 EN: Size must be between 4 and 12 inclusive.<br>
-Length must be between 0 and 20 inclusive.</p></td>
+Must be max 20 characters.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
@@ -1216,36 +1178,36 @@ Size must be between 0 and 1000 inclusive.</p></td>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_3"><a class="anchor" href="#_response_fields_3"></a><a class="link" href="#_response_fields_3">2.3.6. Response fields</a></h4>
+<h4 id="_response_fields_3"><a class="anchor" href="#_response_fields_3"></a><a class="link" href="#_response_fields_3">2.3.5. Response fields</a></h4>
 <div class="paragraph">
 <p>No response body.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_hypermedia_links"><a class="anchor" href="#_hypermedia_links"></a><a class="link" href="#_hypermedia_links">2.3.7. Hypermedia links</a></h4>
+<h4 id="_hypermedia_links"><a class="anchor" href="#_hypermedia_links"></a><a class="link" href="#_hypermedia_links">2.3.6. Hypermedia links</a></h4>
 <div class="paragraph">
 <p>No links.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_embedded_resources"><a class="anchor" href="#_embedded_resources"></a><a class="link" href="#_embedded_resources">2.3.8. Embedded resources</a></h4>
+<h4 id="_embedded_resources"><a class="anchor" href="#_embedded_resources"></a><a class="link" href="#_embedded_resources">2.3.7. Embedded resources</a></h4>
 <div class="paragraph">
 <p>No embedded resources.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_example_request"><a class="anchor" href="#_example_request"></a><a class="link" href="#_example_request">2.3.9. Example request</a></h4>
+<h4 id="_example_request"><a class="anchor" href="#_example_request"></a><a class="link" href="#_example_request">2.3.8. Example request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items' -i -X POST \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer 5f5cb4c9-67a4-44da-bf06-e7d299ed9287' \
+    -H 'Authorization: Bearer 03546d8c-c9b4-4461-b5ab-8ad6ec2c5b8f' \
     -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_example_response"><a class="anchor" href="#_example_response"></a><a class="link" href="#_example_response">2.3.10. Example response</a></h4>
+<h4 id="_example_response"><a class="anchor" href="#_example_response"></a><a class="link" href="#_example_response">2.3.9. Example response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
@@ -1312,47 +1274,7 @@ X-Frame-Options: DENY</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_request_fields_5"><a class="anchor" href="#_request_fields_5"></a><a class="link" href="#_request_fields_5">2.4.4. Request fields</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Parameter</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Optional</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">description</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true<br>
-EN: false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.</p>
-<p class="tableblock">DE: Size must be between 2 and 10 inclusive.<br>
-EN: Size must be between 4 and 12 inclusive.<br>
-Length must be between 0 and 20 inclusive.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Country dependent type of the item.</p>
-<p class="tableblock">DE: Must be one of [klein, groß].<br>
-EN: Must be one of [small, big].<br>
-Size must be between 0 and 1000 inclusive.</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_request_fields_6"><a class="anchor" href="#_request_fields_6"></a><a class="link" href="#_request_fields_6">2.4.5. Request fields</a></h4>
+<h4 id="_request_fields_4"><a class="anchor" href="#_request_fields_4"></a><a class="link" href="#_request_fields_4">2.4.4. Request fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1377,7 +1299,7 @@ EN: false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.</p>
 <p class="tableblock">DE: Size must be between 2 and 10 inclusive.<br>
 EN: Size must be between 4 and 12 inclusive.<br>
-Length must be between 0 and 20 inclusive.</p></td>
+Must be max 20 characters.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
@@ -1392,7 +1314,7 @@ Size must be between 0 and 1000 inclusive.</p></td>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_4"><a class="anchor" href="#_response_fields_4"></a><a class="link" href="#_response_fields_4">2.4.6. Response fields</a></h4>
+<h4 id="_response_fields_4"><a class="anchor" href="#_response_fields_4"></a><a class="link" href="#_response_fields_4">2.4.5. Response fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1525,30 +1447,30 @@ Must be at most 10.</p></td>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_hypermedia_links_2"><a class="anchor" href="#_hypermedia_links_2"></a><a class="link" href="#_hypermedia_links_2">2.4.7. Hypermedia links</a></h4>
+<h4 id="_hypermedia_links_2"><a class="anchor" href="#_hypermedia_links_2"></a><a class="link" href="#_hypermedia_links_2">2.4.6. Hypermedia links</a></h4>
 <div class="paragraph">
 <p>No links.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_embedded_resources_2"><a class="anchor" href="#_embedded_resources_2"></a><a class="link" href="#_embedded_resources_2">2.4.8. Embedded resources</a></h4>
+<h4 id="_embedded_resources_2"><a class="anchor" href="#_embedded_resources_2"></a><a class="link" href="#_embedded_resources_2">2.4.7. Embedded resources</a></h4>
 <div class="paragraph">
 <p>No embedded resources.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_example_request_2"><a class="anchor" href="#_example_request_2"></a><a class="link" href="#_example_request_2">2.4.9. Example request</a></h4>
+<h4 id="_example_request_2"><a class="anchor" href="#_example_request_2"></a><a class="link" href="#_example_request_2">2.4.8. Example request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X PUT \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer 5f5cb4c9-67a4-44da-bf06-e7d299ed9287' \
+    -H 'Authorization: Bearer 03546d8c-c9b4-4461-b5ab-8ad6ec2c5b8f' \
     -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_example_response_2"><a class="anchor" href="#_example_response_2"></a><a class="link" href="#_example_response_2">2.4.10. Example response</a></h4>
+<h4 id="_example_response_2"><a class="anchor" href="#_example_response_2"></a><a class="link" href="#_example_response_2">2.4.9. Example response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -1632,46 +1554,40 @@ Item must exist.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_request_fields_7"><a class="anchor" href="#_request_fields_7"></a><a class="link" href="#_request_fields_7">2.5.4. Request fields</a></h4>
+<h4 id="_request_fields_5"><a class="anchor" href="#_request_fields_5"></a><a class="link" href="#_request_fields_5">2.5.4. Request fields</a></h4>
 <div class="paragraph">
 <p>No parameters.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_request_fields_8"><a class="anchor" href="#_request_fields_8"></a><a class="link" href="#_request_fields_8">2.5.5. Request fields</a></h4>
-<div class="paragraph">
-<p>No request body.</p>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_response_fields_5"><a class="anchor" href="#_response_fields_5"></a><a class="link" href="#_response_fields_5">2.5.6. Response fields</a></h4>
+<h4 id="_response_fields_5"><a class="anchor" href="#_response_fields_5"></a><a class="link" href="#_response_fields_5">2.5.5. Response fields</a></h4>
 <div class="paragraph">
 <p>No response body.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_hypermedia_links_3"><a class="anchor" href="#_hypermedia_links_3"></a><a class="link" href="#_hypermedia_links_3">2.5.7. Hypermedia links</a></h4>
+<h4 id="_hypermedia_links_3"><a class="anchor" href="#_hypermedia_links_3"></a><a class="link" href="#_hypermedia_links_3">2.5.6. Hypermedia links</a></h4>
 <div class="paragraph">
 <p>No links.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_embedded_resources_3"><a class="anchor" href="#_embedded_resources_3"></a><a class="link" href="#_embedded_resources_3">2.5.8. Embedded resources</a></h4>
+<h4 id="_embedded_resources_3"><a class="anchor" href="#_embedded_resources_3"></a><a class="link" href="#_embedded_resources_3">2.5.7. Embedded resources</a></h4>
 <div class="paragraph">
 <p>No embedded resources.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_example_request_3"><a class="anchor" href="#_example_request_3"></a><a class="link" href="#_example_request_3">2.5.9. Example request</a></h4>
+<h4 id="_example_request_3"><a class="anchor" href="#_example_request_3"></a><a class="link" href="#_example_request_3">2.5.8. Example request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X DELETE \
-    -H 'Authorization: Bearer 5f5cb4c9-67a4-44da-bf06-e7d299ed9287'</code></pre>
+    -H 'Authorization: Bearer 03546d8c-c9b4-4461-b5ab-8ad6ec2c5b8f'</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_example_response_3"><a class="anchor" href="#_example_response_3"></a><a class="link" href="#_example_response_3">2.5.10. Example response</a></h4>
+<h4 id="_example_response_3"><a class="anchor" href="#_example_response_3"></a><a class="link" href="#_example_response_3">2.5.9. Example response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -1748,19 +1664,13 @@ EN: Must be at least 1.</p></td>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_query_parameters_5"><a class="anchor" href="#_query_parameters_5"></a><a class="link" href="#_query_parameters_5">2.6.4. Query parameters</a></h4>
-<div class="paragraph">
-<p>No parameters.</p>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_request_fields_9"><a class="anchor" href="#_request_fields_9"></a><a class="link" href="#_request_fields_9">2.6.5. Request fields</a></h4>
+<h4 id="_request_fields_6"><a class="anchor" href="#_request_fields_6"></a><a class="link" href="#_request_fields_6">2.6.4. Request fields</a></h4>
 <div class="paragraph">
 <p>No request body.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_6"><a class="anchor" href="#_response_fields_6"></a><a class="link" href="#_response_fields_6">2.6.6. Response fields</a></h4>
+<h4 id="_response_fields_6"><a class="anchor" href="#_response_fields_6"></a><a class="link" href="#_response_fields_6">2.6.5. Response fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1893,19 +1803,19 @@ Must be at most 10.</p></td>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_hypermedia_links_4"><a class="anchor" href="#_hypermedia_links_4"></a><a class="link" href="#_hypermedia_links_4">2.6.7. Hypermedia links</a></h4>
+<h4 id="_hypermedia_links_4"><a class="anchor" href="#_hypermedia_links_4"></a><a class="link" href="#_hypermedia_links_4">2.6.6. Hypermedia links</a></h4>
 <div class="paragraph">
 <p>No links.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_embedded_resources_4"><a class="anchor" href="#_embedded_resources_4"></a><a class="link" href="#_embedded_resources_4">2.6.8. Embedded resources</a></h4>
+<h4 id="_embedded_resources_4"><a class="anchor" href="#_embedded_resources_4"></a><a class="link" href="#_embedded_resources_4">2.6.7. Embedded resources</a></h4>
 <div class="paragraph">
 <p>No embedded resources.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_example_request_4"><a class="anchor" href="#_example_request_4"></a><a class="link" href="#_example_request_4">2.6.9. Example request</a></h4>
+<h4 id="_example_request_4"><a class="anchor" href="#_example_request_4"></a><a class="link" href="#_example_request_4">2.6.8. Example request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/1/child-1' -i -X GET</code></pre>
@@ -1913,7 +1823,7 @@ Must be at most 10.</p></td>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_example_response_4"><a class="anchor" href="#_example_response_4"></a><a class="link" href="#_example_response_4">2.6.10. Example response</a></h4>
+<h4 id="_example_response_4"><a class="anchor" href="#_example_response_4"></a><a class="link" href="#_example_response_4">2.6.9. Example response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -1965,7 +1875,7 @@ Content-Length: 133
 </div>
 </div>
 <div class="sect3">
-<h4 id="_query_parameters_6"><a class="anchor" href="#_query_parameters_6"></a><a class="link" href="#_query_parameters_6">2.7.3. Query parameters</a></h4>
+<h4 id="_query_parameters_5"><a class="anchor" href="#_query_parameters_5"></a><a class="link" href="#_query_parameters_5">2.7.3. Query parameters</a></h4>
 <div class="paragraph">
 <p>Uses <a href="#overview-pagination">pagination</a> query params.</p>
 </div>
@@ -2004,19 +1914,13 @@ Must be at most 100.</p></td>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_query_parameters_7"><a class="anchor" href="#_query_parameters_7"></a><a class="link" href="#_query_parameters_7">2.7.4. Query parameters</a></h4>
-<div class="paragraph">
-<p>Uses <a href="#overview-pagination">pagination</a> query params.</p>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_request_fields_10"><a class="anchor" href="#_request_fields_10"></a><a class="link" href="#_request_fields_10">2.7.5. Request fields</a></h4>
+<h4 id="_request_fields_7"><a class="anchor" href="#_request_fields_7"></a><a class="link" href="#_request_fields_7">2.7.4. Request fields</a></h4>
 <div class="paragraph">
 <p>No request body.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_7"><a class="anchor" href="#_response_fields_7"></a><a class="link" href="#_response_fields_7">2.7.6. Response fields</a></h4>
+<h4 id="_response_fields_7"><a class="anchor" href="#_response_fields_7"></a><a class="link" href="#_response_fields_7">2.7.5. Response fields</a></h4>
 <div class="paragraph">
 <p><a href="#overview-pagination">Pagination</a> response with following <code>content</code>:</p>
 </div>
@@ -2152,19 +2056,19 @@ Must be at most 10.</p></td>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_hypermedia_links_5"><a class="anchor" href="#_hypermedia_links_5"></a><a class="link" href="#_hypermedia_links_5">2.7.7. Hypermedia links</a></h4>
+<h4 id="_hypermedia_links_5"><a class="anchor" href="#_hypermedia_links_5"></a><a class="link" href="#_hypermedia_links_5">2.7.6. Hypermedia links</a></h4>
 <div class="paragraph">
 <p>No links.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_embedded_resources_5"><a class="anchor" href="#_embedded_resources_5"></a><a class="link" href="#_embedded_resources_5">2.7.8. Embedded resources</a></h4>
+<h4 id="_embedded_resources_5"><a class="anchor" href="#_embedded_resources_5"></a><a class="link" href="#_embedded_resources_5">2.7.7. Embedded resources</a></h4>
 <div class="paragraph">
 <p>No embedded resources.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_example_request_5"><a class="anchor" href="#_example_request_5"></a><a class="link" href="#_example_request_5">2.7.9. Example request</a></h4>
+<h4 id="_example_request_5"><a class="anchor" href="#_example_request_5"></a><a class="link" href="#_example_request_5">2.7.8. Example request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/search?desc=main&amp;hint=1' -i -X GET</code></pre>
@@ -2172,7 +2076,7 @@ Must be at most 10.</p></td>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_example_response_5"><a class="anchor" href="#_example_response_5"></a><a class="link" href="#_example_response_5">2.7.10. Example response</a></h4>
+<h4 id="_example_response_5"><a class="anchor" href="#_example_response_5"></a><a class="link" href="#_example_response_5">2.7.9. Example response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -2227,13 +2131,13 @@ Content-Length: 1072
     "paged" : true
   },
   "total" : 1,
+  "last" : true,
   "totalPages" : 1,
   "totalElements" : 1,
-  "last" : true,
-  "size" : 20,
   "numberOfElements" : 1,
   "first" : true,
   "number" : 0,
+  "size" : 20,
   "sort" : {
     "orders" : [ ],
     "sorted" : false,
@@ -2270,19 +2174,13 @@ Content-Length: 1072
 </div>
 </div>
 <div class="sect3">
-<h4 id="_query_parameters_8"><a class="anchor" href="#_query_parameters_8"></a><a class="link" href="#_query_parameters_8">2.8.3. Query parameters</a></h4>
+<h4 id="_query_parameters_6"><a class="anchor" href="#_query_parameters_6"></a><a class="link" href="#_query_parameters_6">2.8.3. Query parameters</a></h4>
 <div class="paragraph">
 <p>No parameters.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_request_fields_11"><a class="anchor" href="#_request_fields_11"></a><a class="link" href="#_request_fields_11">2.8.4. Request fields</a></h4>
-<div class="paragraph">
-<p>No parameters.</p>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_request_fields_12"><a class="anchor" href="#_request_fields_12"></a><a class="link" href="#_request_fields_12">2.8.5. Request fields</a></h4>
+<h4 id="_request_fields_8"><a class="anchor" href="#_request_fields_8"></a><a class="link" href="#_request_fields_8">2.8.4. Request fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2309,7 +2207,7 @@ Content-Length: 1072
 </table>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_8"><a class="anchor" href="#_response_fields_8"></a><a class="link" href="#_response_fields_8">2.8.6. Response fields</a></h4>
+<h4 id="_response_fields_8"><a class="anchor" href="#_response_fields_8"></a><a class="link" href="#_response_fields_8">2.8.5. Response fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2336,19 +2234,19 @@ Content-Length: 1072
 </table>
 </div>
 <div class="sect3">
-<h4 id="_hypermedia_links_6"><a class="anchor" href="#_hypermedia_links_6"></a><a class="link" href="#_hypermedia_links_6">2.8.7. Hypermedia links</a></h4>
+<h4 id="_hypermedia_links_6"><a class="anchor" href="#_hypermedia_links_6"></a><a class="link" href="#_hypermedia_links_6">2.8.6. Hypermedia links</a></h4>
 <div class="paragraph">
 <p>No links.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_embedded_resources_6"><a class="anchor" href="#_embedded_resources_6"></a><a class="link" href="#_embedded_resources_6">2.8.8. Embedded resources</a></h4>
+<h4 id="_embedded_resources_6"><a class="anchor" href="#_embedded_resources_6"></a><a class="link" href="#_embedded_resources_6">2.8.7. Embedded resources</a></h4>
 <div class="paragraph">
 <p>No embedded resources.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_example_request_6"><a class="anchor" href="#_example_request_6"></a><a class="link" href="#_example_request_6">2.8.9. Example request</a></h4>
+<h4 id="_example_request_6"><a class="anchor" href="#_example_request_6"></a><a class="link" href="#_example_request_6">2.8.8. Example request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/process' -i -X POST \
@@ -2358,7 +2256,7 @@ Content-Length: 1072
 </div>
 </div>
 <div class="sect3">
-<h4 id="_example_response_6"><a class="anchor" href="#_example_response_6"></a><a class="link" href="#_example_response_6">2.8.10. Example response</a></h4>
+<h4 id="_example_response_6"><a class="anchor" href="#_example_response_6"></a><a class="link" href="#_example_response_6">2.8.9. Example response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -2437,13 +2335,13 @@ This endpoint demos the basic support for @ModelAttribute.</p>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_query_parameters_9"><a class="anchor" href="#_query_parameters_9"></a><a class="link" href="#_query_parameters_9">2.9.3. Query parameters</a></h4>
+<h4 id="_query_parameters_7"><a class="anchor" href="#_query_parameters_7"></a><a class="link" href="#_query_parameters_7">2.9.3. Query parameters</a></h4>
 <div class="paragraph">
 <p>No parameters.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_request_fields_13"><a class="anchor" href="#_request_fields_13"></a><a class="link" href="#_request_fields_13">2.9.4. Request fields</a></h4>
+<h4 id="_request_fields_9"><a class="anchor" href="#_request_fields_9"></a><a class="link" href="#_request_fields_9">2.9.4. Request fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2470,13 +2368,7 @@ This endpoint demos the basic support for @ModelAttribute.</p>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_request_fields_14"><a class="anchor" href="#_request_fields_14"></a><a class="link" href="#_request_fields_14">2.9.5. Request fields</a></h4>
-<div class="paragraph">
-<p>No request body.</p>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_response_fields_9"><a class="anchor" href="#_response_fields_9"></a><a class="link" href="#_response_fields_9">2.9.6. Response fields</a></h4>
+<h4 id="_response_fields_9"><a class="anchor" href="#_response_fields_9"></a><a class="link" href="#_response_fields_9">2.9.5. Response fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2503,19 +2395,19 @@ This endpoint demos the basic support for @ModelAttribute.</p>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_hypermedia_links_7"><a class="anchor" href="#_hypermedia_links_7"></a><a class="link" href="#_hypermedia_links_7">2.9.7. Hypermedia links</a></h4>
+<h4 id="_hypermedia_links_7"><a class="anchor" href="#_hypermedia_links_7"></a><a class="link" href="#_hypermedia_links_7">2.9.6. Hypermedia links</a></h4>
 <div class="paragraph">
 <p>No links.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_embedded_resources_7"><a class="anchor" href="#_embedded_resources_7"></a><a class="link" href="#_embedded_resources_7">2.9.8. Embedded resources</a></h4>
+<h4 id="_embedded_resources_7"><a class="anchor" href="#_embedded_resources_7"></a><a class="link" href="#_embedded_resources_7">2.9.7. Embedded resources</a></h4>
 <div class="paragraph">
 <p>No embedded resources.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_example_request_7"><a class="anchor" href="#_example_request_7"></a><a class="link" href="#_example_request_7">2.9.9. Example request</a></h4>
+<h4 id="_example_request_7"><a class="anchor" href="#_example_request_7"></a><a class="link" href="#_example_request_7">2.9.8. Example request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/1/process' -i -X POST \
@@ -2525,7 +2417,7 @@ This endpoint demos the basic support for @ModelAttribute.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_example_response_7"><a class="anchor" href="#_example_response_7"></a><a class="link" href="#_example_response_7">2.9.10. Example response</a></h4>
+<h4 id="_example_response_7"><a class="anchor" href="#_example_response_7"></a><a class="link" href="#_example_response_7">2.9.9. Example response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -2569,66 +2461,13 @@ Content-Length: 55
 </div>
 </div>
 <div class="sect3">
-<h4 id="_query_parameters_10"><a class="anchor" href="#_query_parameters_10"></a><a class="link" href="#_query_parameters_10">2.10.3. Query parameters</a></h4>
+<h4 id="_query_parameters_8"><a class="anchor" href="#_query_parameters_8"></a><a class="link" href="#_query_parameters_8">2.10.3. Query parameters</a></h4>
 <div class="paragraph">
 <p>No parameters.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_request_fields_15"><a class="anchor" href="#_request_fields_15"></a><a class="link" href="#_request_fields_15">2.10.4. Request fields</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Parameter</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Optional</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Determines the type of metadata.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">tag</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true (Available if metadata type=1)<br>
-true (Available in specific conditions)</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Tag attribute. (Available if metadata type=1)<br>
-Tag attribute. (Available in specific conditions).</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">order</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true (Available if metadata type=2)</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Order attribute. (Available if metadata type=2).</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">sub</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Object</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true (Available if metadata type=2)</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Sub metadata (recursive). Not expanded as client should not see it. (Available if metadata type=2).</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">info</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true (Available in specific conditions)</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Info attribute. (Available in specific conditions).</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_request_fields_16"><a class="anchor" href="#_request_fields_16"></a><a class="link" href="#_request_fields_16">2.10.5. Request fields</a></h4>
+<h4 id="_request_fields_10"><a class="anchor" href="#_request_fields_10"></a><a class="link" href="#_request_fields_10">2.10.4. Request fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2681,25 +2520,25 @@ Tag attribute. (Available in specific conditions).</p></td>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_10"><a class="anchor" href="#_response_fields_10"></a><a class="link" href="#_response_fields_10">2.10.6. Response fields</a></h4>
+<h4 id="_response_fields_10"><a class="anchor" href="#_response_fields_10"></a><a class="link" href="#_response_fields_10">2.10.5. Response fields</a></h4>
 <div class="paragraph">
 <p>No response body.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_hypermedia_links_8"><a class="anchor" href="#_hypermedia_links_8"></a><a class="link" href="#_hypermedia_links_8">2.10.7. Hypermedia links</a></h4>
+<h4 id="_hypermedia_links_8"><a class="anchor" href="#_hypermedia_links_8"></a><a class="link" href="#_hypermedia_links_8">2.10.6. Hypermedia links</a></h4>
 <div class="paragraph">
 <p>No links.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_embedded_resources_8"><a class="anchor" href="#_embedded_resources_8"></a><a class="link" href="#_embedded_resources_8">2.10.8. Embedded resources</a></h4>
+<h4 id="_embedded_resources_8"><a class="anchor" href="#_embedded_resources_8"></a><a class="link" href="#_embedded_resources_8">2.10.7. Embedded resources</a></h4>
 <div class="paragraph">
 <p>No embedded resources.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_example_request_8"><a class="anchor" href="#_example_request_8"></a><a class="link" href="#_example_request_8">2.10.9. Example request</a></h4>
+<h4 id="_example_request_8"><a class="anchor" href="#_example_request_8"></a><a class="link" href="#_example_request_8">2.10.8. Example request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/validateMetadata' -i -X POST \
@@ -2709,7 +2548,7 @@ Tag attribute. (Available in specific conditions).</p></td>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_example_response_8"><a class="anchor" href="#_example_response_8"></a><a class="link" href="#_example_response_8">2.10.10. Example response</a></h4>
+<h4 id="_example_response_8"><a class="anchor" href="#_example_response_8"></a><a class="link" href="#_example_response_8">2.10.9. Example response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -2750,41 +2589,13 @@ X-Frame-Options: DENY</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_query_parameters_11"><a class="anchor" href="#_query_parameters_11"></a><a class="link" href="#_query_parameters_11">2.11.3. Query parameters</a></h4>
+<h4 id="_query_parameters_9"><a class="anchor" href="#_query_parameters_9"></a><a class="link" href="#_query_parameters_9">2.11.3. Query parameters</a></h4>
 <div class="paragraph">
 <p>No parameters.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_request_fields_17"><a class="anchor" href="#_request_fields_17"></a><a class="link" href="#_request_fields_17">2.11.4. Request fields</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Parameter</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Optional</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Deprecated.</strong></p>
-<p class="tableblock">New item&#8217;s name.</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_request_fields_18"><a class="anchor" href="#_request_fields_18"></a><a class="link" href="#_request_fields_18">2.11.5. Request fields</a></h4>
+<h4 id="_request_fields_11"><a class="anchor" href="#_request_fields_11"></a><a class="link" href="#_request_fields_11">2.11.4. Request fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2812,25 +2623,25 @@ X-Frame-Options: DENY</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_11"><a class="anchor" href="#_response_fields_11"></a><a class="link" href="#_response_fields_11">2.11.6. Response fields</a></h4>
+<h4 id="_response_fields_11"><a class="anchor" href="#_response_fields_11"></a><a class="link" href="#_response_fields_11">2.11.5. Response fields</a></h4>
 <div class="paragraph">
 <p>No response body.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_hypermedia_links_9"><a class="anchor" href="#_hypermedia_links_9"></a><a class="link" href="#_hypermedia_links_9">2.11.7. Hypermedia links</a></h4>
+<h4 id="_hypermedia_links_9"><a class="anchor" href="#_hypermedia_links_9"></a><a class="link" href="#_hypermedia_links_9">2.11.6. Hypermedia links</a></h4>
 <div class="paragraph">
 <p>No links.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_embedded_resources_9"><a class="anchor" href="#_embedded_resources_9"></a><a class="link" href="#_embedded_resources_9">2.11.8. Embedded resources</a></h4>
+<h4 id="_embedded_resources_9"><a class="anchor" href="#_embedded_resources_9"></a><a class="link" href="#_embedded_resources_9">2.11.7. Embedded resources</a></h4>
 <div class="paragraph">
 <p>No embedded resources.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_example_request_9"><a class="anchor" href="#_example_request_9"></a><a class="link" href="#_example_request_9">2.11.9. Example request</a></h4>
+<h4 id="_example_request_9"><a class="anchor" href="#_example_request_9"></a><a class="link" href="#_example_request_9">2.11.8. Example request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/cloneItem' -i -X POST \
@@ -2840,7 +2651,7 @@ X-Frame-Options: DENY</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_example_response_9"><a class="anchor" href="#_example_response_9"></a><a class="link" href="#_example_response_9">2.11.10. Example response</a></h4>
+<h4 id="_example_response_9"><a class="anchor" href="#_example_response_9"></a><a class="link" href="#_example_response_9">2.11.9. Example response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -2900,7 +2711,7 @@ X-Frame-Options: DENY</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_query_parameters_12"><a class="anchor" href="#_query_parameters_12"></a><a class="link" href="#_query_parameters_12">2.12.3. Query parameters</a></h4>
+<h4 id="_query_parameters_10"><a class="anchor" href="#_query_parameters_10"></a><a class="link" href="#_query_parameters_10">2.12.3. Query parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2927,19 +2738,13 @@ X-Frame-Options: DENY</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_query_parameters_13"><a class="anchor" href="#_query_parameters_13"></a><a class="link" href="#_query_parameters_13">2.12.4. Query parameters</a></h4>
-<div class="paragraph">
-<p>No parameters.</p>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_request_fields_19"><a class="anchor" href="#_request_fields_19"></a><a class="link" href="#_request_fields_19">2.12.5. Request fields</a></h4>
+<h4 id="_request_fields_12"><a class="anchor" href="#_request_fields_12"></a><a class="link" href="#_request_fields_12">2.12.4. Request fields</a></h4>
 <div class="paragraph">
 <p>No request body.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_12"><a class="anchor" href="#_response_fields_12"></a><a class="link" href="#_response_fields_12">2.12.6. Response fields</a></h4>
+<h4 id="_response_fields_12"><a class="anchor" href="#_response_fields_12"></a><a class="link" href="#_response_fields_12">2.12.5. Response fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2972,7 +2777,7 @@ X-Frame-Options: DENY</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_hypermedia_links_10"><a class="anchor" href="#_hypermedia_links_10"></a><a class="link" href="#_hypermedia_links_10">2.12.7. Hypermedia links</a></h4>
+<h4 id="_hypermedia_links_10"><a class="anchor" href="#_hypermedia_links_10"></a><a class="link" href="#_hypermedia_links_10">2.12.6. Hypermedia links</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -3007,7 +2812,7 @@ X-Frame-Options: DENY</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_embedded_resources_10"><a class="anchor" href="#_embedded_resources_10"></a><a class="link" href="#_embedded_resources_10">2.12.8. Embedded resources</a></h4>
+<h4 id="_embedded_resources_10"><a class="anchor" href="#_embedded_resources_10"></a><a class="link" href="#_embedded_resources_10">2.12.7. Embedded resources</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3046,7 +2851,7 @@ X-Frame-Options: DENY</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_example_request_10"><a class="anchor" href="#_example_request_10"></a><a class="link" href="#_example_request_10">2.12.9. Example request</a></h4>
+<h4 id="_example_request_10"><a class="anchor" href="#_example_request_10"></a><a class="link" href="#_example_request_10">2.12.8. Example request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/media/1?embedded=true' -i -X GET</code></pre>
@@ -3054,7 +2859,7 @@ X-Frame-Options: DENY</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_example_response_10"><a class="anchor" href="#_example_response_10"></a><a class="link" href="#_example_response_10">2.12.10. Example response</a></h4>
+<h4 id="_example_response_10"><a class="anchor" href="#_example_response_10"></a><a class="link" href="#_example_response_10">2.12.9. Example response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -3151,25 +2956,19 @@ Content-Length: 756
 </table>
 </div>
 <div class="sect3">
-<h4 id="_query_parameters_14"><a class="anchor" href="#_query_parameters_14"></a><a class="link" href="#_query_parameters_14">2.13.3. Query parameters</a></h4>
+<h4 id="_query_parameters_11"><a class="anchor" href="#_query_parameters_11"></a><a class="link" href="#_query_parameters_11">2.13.3. Query parameters</a></h4>
 <div class="paragraph">
 <p>No parameters.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_query_parameters_15"><a class="anchor" href="#_query_parameters_15"></a><a class="link" href="#_query_parameters_15">2.13.4. Query parameters</a></h4>
-<div class="paragraph">
-<p>No parameters.</p>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_request_fields_20"><a class="anchor" href="#_request_fields_20"></a><a class="link" href="#_request_fields_20">2.13.5. Request fields</a></h4>
+<h4 id="_request_fields_13"><a class="anchor" href="#_request_fields_13"></a><a class="link" href="#_request_fields_13">2.13.4. Request fields</a></h4>
 <div class="paragraph">
 <p>No request body.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_13"><a class="anchor" href="#_response_fields_13"></a><a class="link" href="#_response_fields_13">2.13.6. Response fields</a></h4>
+<h4 id="_response_fields_13"><a class="anchor" href="#_response_fields_13"></a><a class="link" href="#_response_fields_13">2.13.5. Response fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3302,7 +3101,7 @@ Must be at most 10.</p></td>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_hypermedia_links_11"><a class="anchor" href="#_hypermedia_links_11"></a><a class="link" href="#_hypermedia_links_11">2.13.7. Hypermedia links</a></h4>
+<h4 id="_hypermedia_links_11"><a class="anchor" href="#_hypermedia_links_11"></a><a class="link" href="#_hypermedia_links_11">2.13.6. Hypermedia links</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -3326,13 +3125,13 @@ Must be at most 10.</p></td>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_embedded_resources_11"><a class="anchor" href="#_embedded_resources_11"></a><a class="link" href="#_embedded_resources_11">2.13.8. Embedded resources</a></h4>
+<h4 id="_embedded_resources_11"><a class="anchor" href="#_embedded_resources_11"></a><a class="link" href="#_embedded_resources_11">2.13.7. Embedded resources</a></h4>
 <div class="paragraph">
 <p>No embedded resources.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_example_request_11"><a class="anchor" href="#_example_request_11"></a><a class="link" href="#_example_request_11">2.13.9. Example request</a></h4>
+<h4 id="_example_request_11"><a class="anchor" href="#_example_request_11"></a><a class="link" href="#_example_request_11">2.13.8. Example request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/resources/1' -i -X GET</code></pre>
@@ -3340,7 +3139,7 @@ Must be at most 10.</p></td>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_example_response_11"><a class="anchor" href="#_example_response_11"></a><a class="link" href="#_example_response_11">2.13.10. Example response</a></h4>
+<h4 id="_example_response_11"><a class="anchor" href="#_example_response_11"></a><a class="link" href="#_example_response_11">2.13.9. Example response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -3387,6 +3186,441 @@ Content-Length: 557
 </div>
 </div>
 </div>
+<div class="sect2">
+<h3 id="resources-item-resource-test-get-item-with-filter"><a class="anchor" href="#resources-item-resource-test-get-item-with-filter"></a><a class="link" href="#resources-item-resource-test-get-item-with-filter">2.14. Get Item With Filter</a></h3>
+<div class="paragraph">
+<p><code>GET /items/filtered</code></p>
+</div>
+<div class="paragraph">
+<p>Returns item with filtering.</p>
+</div>
+<div class="paragraph">
+<p>Shows how model attribute can be used with query parameters.</p>
+</div>
+<div class="sect3">
+<h4 id="_authorization_14"><a class="anchor" href="#_authorization_14"></a><a class="link" href="#_authorization_14">2.14.1. Authorization</a></h4>
+<div class="paragraph">
+<p>OAuth2: Resource is public.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_path_parameters_13"><a class="anchor" href="#_path_parameters_13"></a><a class="link" href="#_path_parameters_13">2.14.2. Path parameters</a></h4>
+<div class="paragraph">
+<p>No parameters.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_query_parameters_12"><a class="anchor" href="#_query_parameters_12"></a><a class="link" href="#_query_parameters_12">2.14.3. Query parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Filter by name.</p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">tag</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Only items with this tag should be returned.</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_request_fields_14"><a class="anchor" href="#_request_fields_14"></a><a class="link" href="#_request_fields_14">2.14.4. Request fields</a></h4>
+<div class="paragraph">
+<p>No request body.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_14"><a class="anchor" href="#_response_fields_14"></a><a class="link" href="#_response_fields_14">2.14.5. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].id</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Unique ID. This text comes directly from Javadoc.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].meta</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Object</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Metadata.</p>
+<p class="tableblock">An example of JsonSubType support. Jackson type documentation&lt;/a&gt;<br>
+See <a href="https://github.com/FasterXML/jackson-annotations/wiki/Jackson-Annotations#type-handling"> Jackson type documentation</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].meta.type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Determines the type of metadata.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].meta.tag</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true (Available if metadata type=1)<br>
+true (Available in specific conditions)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Tag attribute. (Available if metadata type=1)<br>
+Tag attribute. (Available in specific conditions).</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].meta.order</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true (Available if metadata type=2)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Order attribute. (Available if metadata type=2).</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].meta.sub</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Object</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true (Available if metadata type=2)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Sub metadata (recursive). Not expanded as client should not see it. (Available if metadata type=2).</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].meta.info</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true (Available in specific conditions)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Info attribute. (Available in specific conditions).</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Object</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Item attributes.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.text</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Textual attribute.</p>
+<p class="tableblock">Size must be between 2 and 20 inclusive.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.number</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer attribute.</p>
+<p class="tableblock">Must be at least 1.<br>
+Must be at most 10.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.bool</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean attribute.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.decimal</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Decimal</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Decimal attribute.</p>
+<p class="tableblock">Must be at least 1.<br>
+Must be at most 10.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.amount</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Amount attribute.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].attributes.enumType</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Enum attribute.</p>
+<p class="tableblock">Must be one of [ONE, TWO].</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].children</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Array[Object]</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Child items (recursive). Same structure as this response.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].tags</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Array[String]</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Tags.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[].description</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Some information | description about the item.</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_hypermedia_links_12"><a class="anchor" href="#_hypermedia_links_12"></a><a class="link" href="#_hypermedia_links_12">2.14.6. Hypermedia links</a></h4>
+<div class="paragraph">
+<p>No links.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_embedded_resources_12"><a class="anchor" href="#_embedded_resources_12"></a><a class="link" href="#_embedded_resources_12">2.14.7. Embedded resources</a></h4>
+<div class="paragraph">
+<p>No embedded resources.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_example_request_12"><a class="anchor" href="#_example_request_12"></a><a class="link" href="#_example_request_12">2.14.8. Example request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/filtered?name=abc&amp;tag=prod' -i -X GET</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_example_response_12"><a class="anchor" href="#_example_response_12"></a><a class="link" href="#_example_response_12">2.14.9. Example response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY
+Content-Length: 463
+
+[ {
+  "id" : "1",
+  "meta" : {
+    "type" : "1",
+    "tag" : "meta1"
+  },
+  "attributes" : {
+    "text" : "first item",
+    "number" : 1,
+    "bool" : true,
+    "decimal" : 1.11,
+    "amount" : "3.14 EUR",
+    "enumType" : "ONE"
+  },
+  "children" : [ {
+    "id" : "child-1",
+    "meta" : null,
+    "attributes" : null,
+    "children" : null,
+    "tags" : null,
+    "description" : "first child"
+  } ],
+  "tags" : [ "top-level" ],
+  "description" : "main item"
+} ]</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="resources-item-resource-test-update-item-with-filter"><a class="anchor" href="#resources-item-resource-test-update-item-with-filter"></a><a class="link" href="#resources-item-resource-test-update-item-with-filter">2.15. Update Item With Filter</a></h3>
+<div class="paragraph">
+<p><code>PUT /items/filtered/{id}</code></p>
+</div>
+<div class="paragraph">
+<p>Updates existing item only if filter applies.</p>
+</div>
+<div class="paragraph">
+<p>Shows how model attribute can be used with request body.</p>
+</div>
+<div class="sect3">
+<h4 id="_authorization_15"><a class="anchor" href="#_authorization_15"></a><a class="link" href="#_authorization_15">2.15.1. Authorization</a></h4>
+<div class="paragraph">
+<p>OAuth2: User access token required.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_path_parameters_14"><a class="anchor" href="#_path_parameters_14"></a><a class="link" href="#_path_parameters_14">2.15.2. Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">id</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Item ID.</p>
+<p class="tableblock">Must be a valid ID.</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_query_parameters_13"><a class="anchor" href="#_query_parameters_13"></a><a class="link" href="#_query_parameters_13">2.15.3. Query parameters</a></h4>
+<div class="paragraph">
+<p>No parameters.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_request_fields_15"><a class="anchor" href="#_request_fields_15"></a><a class="link" href="#_request_fields_15">2.15.4. Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">tag</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Only items with this tag should be returned.</p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">description</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true<br>
+EN: false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Some information about the item.</p>
+<p class="tableblock">DE: Size must be between 2 and 10 inclusive.<br>
+EN: Size must be between 4 and 12 inclusive.<br>
+Must be max 20 characters.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Country dependent type of the item.</p>
+<p class="tableblock">DE: Must be one of [klein, groß].<br>
+EN: Must be one of [small, big].<br>
+Size must be between 0 and 1000 inclusive.</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_15"><a class="anchor" href="#_response_fields_15"></a><a class="link" href="#_response_fields_15">2.15.5. Response fields</a></h4>
+<div class="paragraph">
+<p>No response body.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_hypermedia_links_13"><a class="anchor" href="#_hypermedia_links_13"></a><a class="link" href="#_hypermedia_links_13">2.15.6. Hypermedia links</a></h4>
+<div class="paragraph">
+<p>No links.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_embedded_resources_13"><a class="anchor" href="#_embedded_resources_13"></a><a class="link" href="#_embedded_resources_13">2.15.7. Embedded resources</a></h4>
+<div class="paragraph">
+<p>No embedded resources.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_example_request_13"><a class="anchor" href="#_example_request_13"></a><a class="link" href="#_example_request_13">2.15.8. Example request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/filtered/1' -i -X PUT \
+    -H 'Content-Type: application/json' \
+    -H 'Authorization: Bearer 03546d8c-c9b4-4461-b5ab-8ad6ec2c5b8f' \
+    -d '{"description":"Hot News"}'</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_example_response_13"><a class="anchor" href="#_example_response_13"></a><a class="link" href="#_example_response_13">2.15.9. Example response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY</code></pre>
+</div>
+</div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -3411,13 +3645,13 @@ All is configured together to compose a convenient section snippet.</p>
 <p>An example of returning a custom response type and custom exception with response status.</p>
 </div>
 <div class="sect3">
-<h4 id="_authorization_14"><a class="anchor" href="#_authorization_14"></a><a class="link" href="#_authorization_14">3.1.1. Authorization</a></h4>
+<h4 id="_authorization_16"><a class="anchor" href="#_authorization_16"></a><a class="link" href="#_authorization_16">3.1.1. Authorization</a></h4>
 <div class="paragraph">
 <p>OAuth2: Resource is public.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_path_parameters_13"><a class="anchor" href="#_path_parameters_13"></a><a class="link" href="#_path_parameters_13">3.1.2. Path parameters</a></h4>
+<h4 id="_path_parameters_15"><a class="anchor" href="#_path_parameters_15"></a><a class="link" href="#_path_parameters_15">3.1.2. Path parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 3. /items/{id}</caption>
 <colgroup>
@@ -3439,19 +3673,19 @@ All is configured together to compose a convenient section snippet.</p>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_query_parameters_16"><a class="anchor" href="#_query_parameters_16"></a><a class="link" href="#_query_parameters_16">3.1.3. Query parameters</a></h4>
+<h4 id="_query_parameters_14"><a class="anchor" href="#_query_parameters_14"></a><a class="link" href="#_query_parameters_14">3.1.3. Query parameters</a></h4>
 <div class="paragraph">
 <p>No parameters.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_request_fields_21"><a class="anchor" href="#_request_fields_21"></a><a class="link" href="#_request_fields_21">3.1.4. Request fields</a></h4>
+<h4 id="_request_fields_16"><a class="anchor" href="#_request_fields_16"></a><a class="link" href="#_request_fields_16">3.1.4. Request fields</a></h4>
 <div class="paragraph">
 <p>No request body.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_14"><a class="anchor" href="#_response_fields_14"></a><a class="link" href="#_response_fields_14">3.1.5. Response fields</a></h4>
+<h4 id="_response_fields_16"><a class="anchor" href="#_response_fields_16"></a><a class="link" href="#_response_fields_16">3.1.5. Response fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -3475,7 +3709,7 @@ All is configured together to compose a convenient section snippet.</p>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_example_request_12"><a class="anchor" href="#_example_request_12"></a><a class="link" href="#_example_request_12">3.1.6. Example request</a></h4>
+<h4 id="_example_request_14"><a class="anchor" href="#_example_request_14"></a><a class="link" href="#_example_request_14">3.1.6. Example request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/items/1' -i -X GET</code></pre>
@@ -3483,7 +3717,7 @@ All is configured together to compose a convenient section snippet.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_example_response_12"><a class="anchor" href="#_example_response_12"></a><a class="link" href="#_example_response_12">3.1.7. Example response</a></h4>
+<h4 id="_example_response_14"><a class="anchor" href="#_example_response_14"></a><a class="link" href="#_example_response_14">3.1.7. Example response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -3530,7 +3764,7 @@ Content-Length: 459
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2020-04-12 14:15:02 +0200
+Last updated 2020-02-10 13:59:32 +0100
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/styles/github.min.css">

--- a/samples/java-webmvc/pom.xml
+++ b/samples/java-webmvc/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>capital.scalable</groupId>
     <artifactId>spring-auto-restdocs-java-webmvc-example</artifactId>
-    <version>2.0.9-SNAPSHOT</version>
+    <version>2.0.9</version>
 
     <name>Spring Auto REST Docs Java Web MVC Example Project</name>
     <description>Example project for Spring Auto REST Docs</description>
@@ -35,7 +35,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <start-class>capital.scalable.restdocs.example.Application</start-class>
         <spring-restdocs.version>2.0.4.RELEASE</spring-restdocs.version>
-        <spring-auto-restdocs.version>2.0.9-SNAPSHOT</spring-auto-restdocs.version>
+        <spring-auto-restdocs.version>2.0.9</spring-auto-restdocs.version>
     </properties>
 
     <dependencies>

--- a/samples/kotlin-webmvc/build.gradle
+++ b/samples/kotlin-webmvc/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         kotlinVersion = "1.3.72"
-        springAutoRestDocsVersion = "2.0.9-SNAPSHOT"
+        springAutoRestDocsVersion = "2.0.9"
         springRestDocsVersion = "2.0.4.RELEASE"
         springBootVersion = "2.3.0.RELEASE"
         dokkaPluginVersion = "0.10.1"
@@ -31,7 +31,7 @@ apply plugin: "org.asciidoctor.convert"
 apply plugin: "org.jetbrains.dokka"
 
 group = "capital.scalable"
-version = "2.0.9-SNAPSHOT"
+version = "2.0.9"
 
 description = """Spring Auto REST Docs Kotlin Web MVC Example Project"""
 

--- a/samples/kotlin-webmvc/pom.xml
+++ b/samples/kotlin-webmvc/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>capital.scalable</groupId>
     <artifactId>spring-auto-restdocs-kotlin-webmvc-example</artifactId>
-    <version>2.0.9-SNAPSHOT</version>
+    <version>2.0.9</version>
 
     <name>Spring Auto REST Docs Kotlin Web MVC Example Project</name>
     <description>Example project for Spring Auto REST Docs</description>
@@ -34,7 +34,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring-restdocs.version>2.0.4.RELEASE</spring-restdocs.version>
-        <spring-auto-restdocs.version>2.0.9-SNAPSHOT</spring-auto-restdocs.version>
+        <spring-auto-restdocs.version>2.0.9</spring-auto-restdocs.version>
         <kotlin.version>1.3.72</kotlin.version>
         <dokka.version>0.10.1</dokka.version>
         <jsonDirectory>${project.build.directory}/generated-javadoc-json</jsonDirectory>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>capital.scalable</groupId>
     <artifactId>spring-auto-restdocs-samples</artifactId>
-    <version>2.0.9-SNAPSHOT</version>
+    <version>2.0.9</version>
 
     <packaging>pom</packaging>
 

--- a/samples/shared/pom.xml
+++ b/samples/shared/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>capital.scalable</groupId>
     <artifactId>spring-auto-restdocs-shared-pojos-example</artifactId>
-    <version>2.0.9-SNAPSHOT</version>
+    <version>2.0.9</version>
 
     <name>Spring Auto REST Docs Shared POJOs Example Project</name>
     <description>Example project for Shared POJOs inside Spring Auto REST Docs</description>
@@ -33,7 +33,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring-auto-restdocs.version>2.0.9-SNAPSHOT</spring-auto-restdocs.version>
+        <spring-auto-restdocs.version>2.0.9</spring-auto-restdocs.version>
     </properties>
 
     <dependencies>

--- a/spring-auto-restdocs-annotations/pom.xml
+++ b/spring-auto-restdocs-annotations/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>capital.scalable</groupId>
         <artifactId>spring-auto-restdocs-parent</artifactId>
-        <version>2.0.9-SNAPSHOT</version>
+        <version>2.0.9</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/spring-auto-restdocs-core/pom.xml
+++ b/spring-auto-restdocs-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>capital.scalable</groupId>
         <artifactId>spring-auto-restdocs-parent</artifactId>
-        <version>2.0.9-SNAPSHOT</version>
+        <version>2.0.9</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/spring-auto-restdocs-docs/pom.xml
+++ b/spring-auto-restdocs-docs/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <docs.dir>${project.basedir}/../docs</docs.dir>
-        <latestRelease>2.0.8</latestRelease> <!-- change this when releasing 2.1.0-SNAPSHOT -->
+        <latestRelease>2.0.9</latestRelease> <!-- change this when releasing 2.0.10-SNAPSHOT -->
     </properties>
 
     <build>

--- a/spring-auto-restdocs-docs/pom.xml
+++ b/spring-auto-restdocs-docs/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>capital.scalable</groupId>
         <artifactId>spring-auto-restdocs-parent</artifactId>
-        <version>2.0.9-SNAPSHOT</version>
+        <version>2.0.9</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/spring-auto-restdocs-dokka-json/pom.xml
+++ b/spring-auto-restdocs-dokka-json/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>capital.scalable</groupId>
         <artifactId>spring-auto-restdocs-parent</artifactId>
-        <version>2.0.9-SNAPSHOT</version>
+        <version>2.0.9</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/spring-auto-restdocs-json-doclet-jdk9/pom.xml
+++ b/spring-auto-restdocs-json-doclet-jdk9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>capital.scalable</groupId>
         <artifactId>spring-auto-restdocs-parent</artifactId>
-        <version>2.0.9-SNAPSHOT</version>
+        <version>2.0.9</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/spring-auto-restdocs-json-doclet/pom.xml
+++ b/spring-auto-restdocs-json-doclet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>capital.scalable</groupId>
         <artifactId>spring-auto-restdocs-parent</artifactId>
-        <version>2.0.9-SNAPSHOT</version>
+        <version>2.0.9</version>
         <relativePath>..</relativePath>
     </parent>
 


### PR DESCRIPTION
Changes:
* Update the version number like in https://github.com/ScaCap/spring-auto-restdocs/pull/376
* Update of the main and the sample documentation

Release notes:
* Support for bold, italics, and code in KDoc https://github.com/ScaCap/spring-auto-restdocs/pull/387
* Support for custom messages in annotations https://github.com/ScaCap/spring-auto-restdocs/pull/395
* Open some snippet methods for extension https://github.com/ScaCap/spring-auto-restdocs/pull/396
* Upgrade the Dokka extension Dokka 0.10.1 https://github.com/ScaCap/spring-auto-restdocs/pull/385
* Support for @JsonProperty.Access https://github.com/ScaCap/spring-auto-restdocs/pull/383
* De-duplicate sections of ModelAttribute is present https://github.com/ScaCap/spring-auto-restdocs/pull/393
* Fixed an exception in the `HumanReadableConstraintResolver` https://github.com/ScaCap/spring-auto-restdocs/pull/397
* Upgrade jackson-databind to 2.11.0 https://github.com/ScaCap/spring-auto-restdocs/pull/402
* Project maintenance:
  * Add code style https://github.com/ScaCap/spring-auto-restdocs/pull/394
  * Upgrade the example projects to Spring Boot 2.3.0 https://github.com/ScaCap/spring-auto-restdocs/pull/400
  * More tests for subtypes https://github.com/ScaCap/spring-auto-restdocs/pull/392
  * Test against JDK 14 https://github.com/ScaCap/spring-auto-restdocs/pull/382

