### PR TITLE
Fix mixing modelattribute with other annotations

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2637,7 +2637,7 @@ Create the test JAR by running the following command on the top-level:</p>
 <div id="footer">
 <div id="footer-text">
 Version 2.0.10-SNAPSHOT<br>
-Last updated 2021-02-17 22:38:31 +0100
+Last updated 2021-03-13 16:16:47 +0100
 </div>
 </div>
 <link rel="stylesheet" href="highlight/styles/github.min.css">

--- a/samples/java-webmvc/generated-docs/index.html
+++ b/samples/java-webmvc/generated-docs/index.html
@@ -1207,7 +1207,7 @@ Size must be between 0 and 1000 inclusive.</p></td>
 <div class="content">
 <pre class="highlightjs highlight"><code data-lang="bash" class="language-bash hljs">$ curl 'http://localhost:8080/items' -i -X POST \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer 99d6ee1d-c96a-4385-b391-127dbfce4092' \
+    -H 'Authorization: Bearer 9779cd69-14d4-470b-9069-162881b61f96' \
     -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
@@ -1470,7 +1470,7 @@ Must be at most 10.</p></td>
 <div class="content">
 <pre class="highlightjs highlight"><code data-lang="bash" class="language-bash hljs">$ curl 'http://localhost:8080/items/1' -i -X PUT \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer 99d6ee1d-c96a-4385-b391-127dbfce4092' \
+    -H 'Authorization: Bearer 9779cd69-14d4-470b-9069-162881b61f96' \
     -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
@@ -1588,7 +1588,7 @@ Item must exist.</p>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code data-lang="bash" class="language-bash hljs">$ curl 'http://localhost:8080/items/1' -i -X DELETE \
-    -H 'Authorization: Bearer 99d6ee1d-c96a-4385-b391-127dbfce4092'</code></pre>
+    -H 'Authorization: Bearer 9779cd69-14d4-470b-9069-162881b61f96'</code></pre>
 </div>
 </div>
 </div>
@@ -1918,123 +1918,6 @@ Must be at most 100.</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph">
-<p>Uses <a href="#overview-pagination">pagination</a> query params.</p>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Parameter</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Optional</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">offset</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">paged</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">sort</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Object</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">sort.orders</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Array[Object]</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">sort.orders[].direction</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Must be one of [ASC, DESC].</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">sort.orders[].property</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">sort.orders[].ignoreCase</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">sort.orders[].nullHandling</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Must be one of [NATIVE, NULLS_FIRST, NULLS_LAST].</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">sort.orders[].ascending</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">sort.orders[].descending</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">sort.sorted</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">sort.unsorted</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">sort.empty</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">pageNumber</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">pageSize</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">unpaged</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-</tbody>
-</table>
 </div>
 <div class="sect3">
 <h4 id="_request_fields_7"><a class="anchor" href="#_request_fields_7"></a><a class="link" href="#_request_fields_7">2.7.4. Request fields</a></h4>
@@ -2250,8 +2133,8 @@ Content-Length: 1072
     "offset" : 0,
     "pageNumber" : 0,
     "pageSize" : 20,
-    "paged" : true,
-    "unpaged" : false
+    "unpaged" : false,
+    "paged" : true
   },
   "total" : 1,
   "last" : true,
@@ -2460,11 +2343,14 @@ This endpoint demos the basic support for @ModelAttribute.</p>
 <div class="sect3">
 <h4 id="_query_parameters_7"><a class="anchor" href="#_query_parameters_7"></a><a class="link" href="#_query_parameters_7">2.9.3. Query parameters</a></h4>
 <div class="paragraph">
-<p>No parameters.</p>
+<p>Uses <a href="#overview-pagination">pagination</a> query params.</p>
 </div>
 </div>
 <div class="sect3">
 <h4 id="_request_fields_9"><a class="anchor" href="#_request_fields_9"></a><a class="link" href="#_request_fields_9">2.9.4. Request fields</a></h4>
+<div class="paragraph">
+<p>Uses <a href="#overview-pagination">pagination</a> query params.</p>
+</div>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2486,6 +2372,19 @@ This endpoint demos the basic support for @ModelAttribute.</p>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Command to execute.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">tag</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Only items with this tag should be returned.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Deprecated.</strong></p>
+<p class="tableblock">New item&#8217;s name.</p></td>
 </tr>
 </tbody>
 </table>
@@ -2535,7 +2434,7 @@ This endpoint demos the basic support for @ModelAttribute.</p>
 <div class="content">
 <pre class="highlightjs highlight"><code data-lang="bash" class="language-bash hljs">$ curl 'http://localhost:8080/items/1/process' -i -X POST \
     -H 'Content-Type: application/x-www-form-urlencoded' \
-    -d 'command=increase'</code></pre>
+    -d 'command=increase&amp;tag=processed&amp;page=1&amp;name=myitem'</code></pre>
 </div>
 </div>
 </div>
@@ -2551,10 +2450,10 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 55
+Content-Length: 161
 
 {
-  "output" : "Command executed on item 1: increase"
+  "output" : "Command executed on item 1: increase, method: POST, tag: processed, data: myitem, errors: 0, Page request [number: 1, size 20, sort: UNSORTED]"
 }</code></pre>
 </div>
 </div>
@@ -3724,7 +3623,7 @@ Size must be between 0 and 1000 inclusive.</p></td>
 <div class="content">
 <pre class="highlightjs highlight"><code data-lang="bash" class="language-bash hljs">$ curl 'http://localhost:8080/items/filtered/1' -i -X PUT \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer 99d6ee1d-c96a-4385-b391-127dbfce4092' \
+    -H 'Authorization: Bearer 9779cd69-14d4-470b-9069-162881b61f96' \
     -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>

--- a/samples/java-webmvc/src/main/java/capital/scalable/restdocs/example/items/ItemResource.java
+++ b/samples/java-webmvc/src/main/java/capital/scalable/restdocs/example/items/ItemResource.java
@@ -33,6 +33,7 @@ import java.math.BigDecimal;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 import capital.scalable.restdocs.example.common.Money;
 import capital.scalable.restdocs.example.constraints.English;
@@ -43,8 +44,10 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -240,10 +243,19 @@ public class ItemResource {
      * @title Process One Item
      */
     @PostMapping("{itemId}/process")
-    public CommandResult processSingleItem(@PathVariable String itemId,
-            @ModelAttribute Command command) {
+    public CommandResult processSingleItem(
+            @PathVariable String itemId,
+            @ModelAttribute Command command,
+            HttpMethod method,
+            @ModelAttribute Filter filter,
+            Pageable page,
+            Errors errors,
+            CloneData data
+            ) {
         return new CommandResult(
-                String.format("Command executed on item %s: %s", itemId, command.getCommand()));
+                String.format("Command executed on item %s: %s, method: %s, tag: %s, data: %s, errors: %s, %s",
+                        itemId, command.getCommand(), method, filter.tag, data.name,
+                        errors.getAllErrors().size(), page));
     }
 
     /**
@@ -282,7 +294,8 @@ public class ItemResource {
         HypermediaItemResponse response = new HypermediaItemResponse(id, "hypermedia item");
         response.add(linkTo(methodOn(ItemResource.class).getHypermediaItem(id, embedded)).withSelfRel());
         response.add(linkTo(methodOn(ItemResource.class).getItem(id)).withRel("classicItem"));
-        response.add(linkTo(methodOn(ItemResource.class).processSingleItem(id, null)).withRel("process"));
+        response.add(linkTo(methodOn(ItemResource.class).processSingleItem(id, null, null, null, null, null, null))
+                .withRel("process"));
         if (embedded != null && embedded) {
             response.addEmbedded("children", new Object[] { CHILD });
             response.addEmbedded("attributes", ATTRIBUTES);
@@ -338,6 +351,21 @@ public class ItemResource {
          */
         @Deprecated
         private String name;
+
+        public CloneData() {
+        }
+
+        public CloneData(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
     }
 
     static class Command {
@@ -388,5 +416,20 @@ public class ItemResource {
          * Only items with this tag should be returned.
          */
         private String tag;
+
+        public Filter() {
+        }
+
+        public Filter(String tag) {
+            this.tag = tag;
+        }
+
+        public String getTag() {
+            return tag;
+        }
+
+        public void setTag(String tag) {
+            this.tag = tag;
+        }
     }
 }

--- a/samples/java-webmvc/src/test/java/capital/scalable/restdocs/example/items/ItemResourceTest.java
+++ b/samples/java-webmvc/src/test/java/capital/scalable/restdocs/example/items/ItemResourceTest.java
@@ -151,10 +151,12 @@ public class ItemResourceTest extends MockMvcBase {
     public void processSingleItem() throws Exception {
         mockMvc.perform(post("/items/{itemId}/process", "1")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .content("command=increase"))
+                .content("command=increase&tag=processed&page=1&name=myitem"))
                 .andExpect(status().isOk())
                 .andExpect(
-                        content().json("{ \"output\": \"Command executed on item 1: increase\" }"));
+                        content().json("{ \"output\": \"Command executed on item 1: increase, method: POST, " +
+                                "tag: processed, data: myitem, errors: 0, " +
+                                "Page request [number: 1, size 20, sort: UNSORTED]\" }"));
     }
 
     @Test

--- a/samples/kotlin-webmvc/generated-docs/index.html
+++ b/samples/kotlin-webmvc/generated-docs/index.html
@@ -1156,7 +1156,7 @@ Size must be between 0 and 1000 inclusive.</p></td>
 <div class="content">
 <pre class="highlightjs highlight"><code data-lang="bash" class="language-bash hljs">$ curl 'http://localhost:8080/items' -i -X POST \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer 262558be-e737-4bb1-9a14-fd1ed135ccde' \
+    -H 'Authorization: Bearer c4a4aa02-3d9e-4b7a-882f-f3de0b744d54' \
     -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
@@ -1399,7 +1399,7 @@ Must be at most 10.</p></td>
 <div class="content">
 <pre class="highlightjs highlight"><code data-lang="bash" class="language-bash hljs">$ curl 'http://localhost:8080/items/1' -i -X PUT \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer 262558be-e737-4bb1-9a14-fd1ed135ccde' \
+    -H 'Authorization: Bearer c4a4aa02-3d9e-4b7a-882f-f3de0b744d54' \
     -d '{"description":"Hot News"}'</code></pre>
 </div>
 </div>
@@ -1501,7 +1501,7 @@ Content-Length: 124
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code data-lang="bash" class="language-bash hljs">$ curl 'http://localhost:8080/items/1' -i -X DELETE \
-    -H 'Authorization: Bearer 262558be-e737-4bb1-9a14-fd1ed135ccde'</code></pre>
+    -H 'Authorization: Bearer c4a4aa02-3d9e-4b7a-882f-f3de0b744d54'</code></pre>
 </div>
 </div>
 </div>
@@ -1803,123 +1803,6 @@ Content-Length: 133
 <td class="tableblock halign-left valign-top"><p class="tableblock">Lookup hint.</p>
 <p class="tableblock">Must be at least 10.<br>
 Must be at most 100.</p></td>
-</tr>
-</tbody>
-</table>
-<div class="paragraph">
-<p>Uses <a href="#overview-pagination">pagination</a> query params.</p>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Parameter</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Optional</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">offset</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">paged</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">pageNumber</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">pageSize</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">sort</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Object</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">sort.orders</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Array[Object]</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">sort.orders[].direction</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Must be one of [ASC, DESC].</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">sort.orders[].property</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">sort.orders[].ignoreCase</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">sort.orders[].nullHandling</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Must be one of [NATIVE, NULLS_FIRST, NULLS_LAST].</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">sort.orders[].ascending</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">sort.orders[].descending</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">sort.sorted</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">sort.unsorted</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">sort.empty</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">unpaged</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
 </tr>
 </tbody>
 </table>

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonModelAttributeSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonModelAttributeSnippet.java
@@ -34,10 +34,8 @@ import capital.scalable.restdocs.i18n.SnippetTranslationResolver;
 import capital.scalable.restdocs.jackson.FieldDescriptors;
 import capital.scalable.restdocs.util.HandlerMethodUtil;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.springframework.beans.BeanUtils;
 import org.springframework.core.MethodParameter;
 import org.springframework.restdocs.operation.Operation;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.method.HandlerMethod;
@@ -62,16 +60,18 @@ public class JacksonModelAttributeSnippet extends AbstractJacksonFieldSnippet {
     @Override
     protected Type[] getType(HandlerMethod method) {
         return Arrays.stream(method.getMethodParameters())
-                .filter(param -> isModelAttribute(param) || isProcessedAsModelAttribute(param))
+                .filter(param -> isProcessedAsModelAttribute(param))
                 .map(this::getType)
                 .toArray(Type[]::new);
     }
 
-    private boolean isModelAttribute(MethodParameter param) {
-        return param.getParameterAnnotation(ModelAttribute.class) != null
-                || param.getParameterAnnotations().length == 0 && !BeanUtils.isSimpleProperty(param.getParameterType());
-    }
-
+    /**
+     * Iterates over list of method argument resolvers and returns the first the same way as in
+     * {@link org.springframework.web.method.support.HandlerMethodArgumentResolverComposite#getArgumentResolver(org.springframework.core.MethodParameter)}
+     *
+     * ModelAttributeMethodProcessor is always the last in provided list, therefore we can rely on the fact that if
+     * that one is returned, every other argument resolver failed.
+     */
     private boolean isProcessedAsModelAttribute(MethodParameter param) {
         return handlerMethodArgumentResolvers != null
                 && handlerMethodArgumentResolvers.stream()

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonModelAttributeSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonModelAttributeSnippet.java
@@ -69,7 +69,7 @@ public class JacksonModelAttributeSnippet extends AbstractJacksonFieldSnippet {
      * Iterates over list of method argument resolvers and returns the first the same way as in
      * {@link org.springframework.web.method.support.HandlerMethodArgumentResolverComposite#getArgumentResolver(org.springframework.core.MethodParameter)}
      *
-     * ModelAttributeMethodProcessor is always the last in provided list, therefore we can rely on the fact that if
+     * ModelAttributeMethodProcessor is always the last in the provided list, therefore we can rely on the fact that if
      * that one is returned, every other argument resolver failed.
      */
     private boolean isProcessedAsModelAttribute(MethodParameter param) {

--- a/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonModelAttributeSnippet.java
+++ b/spring-auto-restdocs-core/src/main/java/capital/scalable/restdocs/payload/JacksonModelAttributeSnippet.java
@@ -66,7 +66,7 @@ public class JacksonModelAttributeSnippet extends AbstractJacksonFieldSnippet {
     }
 
     /**
-     * Iterates over list of method argument resolvers and returns the first the same way as in
+     * Iterates over a list of method argument resolvers and returns the first in the same way as in
      * {@link org.springframework.web.method.support.HandlerMethodArgumentResolverComposite#getArgumentResolver(org.springframework.core.MethodParameter)}
      *
      * ModelAttributeMethodProcessor is always the last in the provided list, therefore we can rely on the fact that if

--- a/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/section/SectionSnippetTest.java
+++ b/spring-auto-restdocs-core/src/test/java/capital/scalable/restdocs/section/SectionSnippetTest.java
@@ -43,7 +43,10 @@ import static capital.scalable.restdocs.SnippetRegistry.RESPONSE_FIELDS;
 import static capital.scalable.restdocs.SnippetRegistry.RESPONSE_HEADERS;
 import static capital.scalable.restdocs.section.SectionSnippet.SECTION;
 import static capital.scalable.restdocs.util.FormatUtil.fixLineSeparator;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Lists.list;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.cli.CliDocumentation.curlRequest;
@@ -58,9 +61,13 @@ import java.util.Map;
 import capital.scalable.restdocs.i18n.SnippetTranslationResolver;
 import capital.scalable.restdocs.i18n.TranslationRule;
 import capital.scalable.restdocs.javadoc.JavadocReader;
+import capital.scalable.restdocs.payload.JacksonModelAttributeSnippet;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.util.Lists;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.restdocs.http.HttpDocumentation;
 import org.springframework.restdocs.templates.TemplateFormat;
 import org.springframework.restdocs.templates.TemplateFormats;
@@ -72,6 +79,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.method.annotation.RequestParamMethodArgumentResolver;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.mvc.method.annotation.PathVariableMethodArgumentResolver;
+import org.springframework.web.servlet.mvc.method.annotation.RequestResponseBodyMethodProcessor;
+import org.springframework.web.servlet.mvc.method.annotation.ServletModelAttributeMethodProcessor;
 
 public class SectionSnippetTest {
 
@@ -441,7 +453,7 @@ public class SectionSnippetTest {
                         .attribute(ATTRIBUTE_NAME_DEFAULT_SNIPPETS, Arrays.asList(
                                 requestParameters(),
                                 requestFields(),
-                                modelAttribute(null)))
+                                modelAttribute(standardMarList())))
                         .request("http://localhost/items/1")
                         .build());
 
@@ -473,7 +485,7 @@ public class SectionSnippetTest {
                         .attribute(ATTRIBUTE_NAME_DEFAULT_SNIPPETS, Arrays.asList(
                                 requestParameters(),
                                 requestFields(),
-                                modelAttribute(null)))
+                                modelAttribute(standardMarList())))
                         .request("http://localhost/items/1")
                         .build());
 
@@ -505,7 +517,7 @@ public class SectionSnippetTest {
                         .attribute(ATTRIBUTE_NAME_DEFAULT_SNIPPETS, Arrays.asList(
                                 requestParameters(),
                                 requestFields(),
-                                modelAttribute(null)))
+                                modelAttribute(standardMarList())))
                         .request("http://localhost/items/1")
                         .build());
 
@@ -538,7 +550,7 @@ public class SectionSnippetTest {
                         .attribute(ATTRIBUTE_NAME_DEFAULT_SNIPPETS, Arrays.asList(
                                 requestParameters(),
                                 requestFields(),
-                                modelAttribute(null)))
+                                modelAttribute(standardMarList())))
                         .request("http://localhost/items/1")
                         .build());
 
@@ -570,7 +582,7 @@ public class SectionSnippetTest {
                         .attribute(ATTRIBUTE_NAME_DEFAULT_SNIPPETS, Arrays.asList(
                                 requestParameters(),
                                 requestFields(),
-                                modelAttribute(null)))
+                                modelAttribute(standardMarList())))
                         .request("http://localhost/items/1")
                         .build());
 
@@ -591,7 +603,18 @@ public class SectionSnippetTest {
                                 "include::http-response.adoc[]\n"));
     }
 
+    private ArrayList<HandlerMethodArgumentResolver> standardMarList() {
+        // captures @RequestParam, @RequestBody and @ModelAttribute
+        HandlerMethodArgumentResolver requestParamMar = new RequestParamMethodArgumentResolver(false);
+        HandlerMethodArgumentResolver requestResponseBodyMar =
+                new RequestResponseBodyMethodProcessor(
+                        singletonList(new MappingJackson2HttpMessageConverter(new ObjectMapper())));
+        HandlerMethodArgumentResolver modelAttributeMar = new ServletModelAttributeMethodProcessor(true);
+        return list(requestParamMar, requestResponseBodyMar, modelAttributeMar);
+    }
+
     private static class CustomSnippetTranslationResolver implements SnippetTranslationResolver {
+
 
         private Map<String, String> customTranslations;
 


### PR DESCRIPTION
Fixes #426 for good.

[Other types without annotation](https://docs.spring.io/spring-framework/docs/current/reference/html/web.html#mvc-ann-arguments) handled by other method argument resolvers are not considered when handling model attribute with or without annotation.

Notice the disappearing of `Pageable` fields from documentation.