### PR TITLE
Replace testing against Java 15 with Java 17

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [ 8, 11, 15 ]
+        jdk: [ 8, 11, 17 ]
     name: Build and Run Tests
     runs-on: ubuntu-latest
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -217,14 +217,14 @@
             </modules>
         </profile>
         <profile>
-            <id>java15</id>
+            <id>java17</id>
             <activation>
-                <jdk>15</jdk>
+                <jdk>17</jdk>
             </activation>
             <properties>
-                <java.version>15</java.version>
-                <maven.compiler.source>15</maven.compiler.source>
-                <maven.compiler.target>15</maven.compiler.target>
+                <java.version>11</java.version>
+                <maven.compiler.source>11</maven.compiler.source>
+                <maven.compiler.target>11</maven.compiler.target>
                 <json-doclet.artifactId>spring-auto-restdocs-json-doclet-jdk9</json-doclet.artifactId>
             </properties>
             <modules>


### PR DESCRIPTION
JDK 15 is not supported anymore and JDK 17 is a new LTS version. Thus, we should test with JDK 17 in the test step. Compiling with Java 17 leads to test failures that still need to be analyzed.